### PR TITLE
Add Prometheus Exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,20 @@ New label sets are added automatically when collector invokes modification funct
 metrics = require('metrics')
 ```
 
+#### `metrics.collectors()`
+   Returns a list of created collectors.
+   Designed to be used in exporters in favor of `metrics.collect()`.
+
 #### `metrics.collect()`
+    **NOTE**: You'll probably want to use `metrics.collectors()` instead.
+    Equivalent to:
+    ```lua
+    for _, c in pairs(metrics.collectors()) do_
+        for _, obs in ipairs(c:collect()) do
+            ...  -- handle observation
+        end_
+    end
+    ```
 
   Returns concatenation of `observation` objects across all collectors created.  
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ metrics = require('metrics')
 
   It may be used for calculation some metric right before collecting.
 
+#### `metrics.invoke_callbacks()`
+   Invokes function registered via `metrics.register_callback(<callback>)`
+   Used in exporters.
+
 
 ### Creating and Using Collectors
 

--- a/example/prometheus_export.lua
+++ b/example/prometheus_export.lua
@@ -1,6 +1,8 @@
 #!/usr/bin/env tarantool
 package.path = package.path .. ";../?.lua"
 
+local log = require('log')
+
 -- Create a Metrics Client
 local metrics = require('metrics')
 
@@ -8,7 +10,11 @@ local metrics = require('metrics')
 local httpd = require('http.server')
 local http_handler = require('metrics.plugins.prometheus').collect_http
 httpd.new('0.0.0.0', 8088)
-    :route({path = '/metrics'}, http_handler)
+    :route({path = '/metrics'}, function(...)
+        log.info('---------------------')
+        log.info('Handling GET /metrics')
+        return http_handler(...)
+    end)
     :start()
 
 -- Create Collectors

--- a/example/prometheus_export.lua
+++ b/example/prometheus_export.lua
@@ -1,0 +1,32 @@
+#!/usr/bin/env tarantool
+package.path = package.path .. ";../?.lua"
+
+-- Create a Metrics Client
+local metrics = require('metrics')
+
+-- Init Prometheus Exporter
+local httpd = require('http.server')
+local http_handler = require('metrics.plugins.prometheus').collect_http
+httpd.new('0.0.0.0', 8088)
+    :route({path = '/metrics'}, http_handler)
+    :start()
+
+-- Create Collectors
+local http_requests_total_counter = metrics.counter('http_requests_total')
+local cpu_usage_gauge = metrics.gauge('cpu_usage')
+local http_requests_total_hist = metrics.histogram('http_requests_total', nil, {2, 4, 6})
+
+-- Use Collectors
+http_requests_total_counter:inc(1, {method = 'GET'})
+cpu_usage_gauge:set(0.24, {app = 'tarantool'})
+http_requests_total_hist:observe(1)
+
+-- Register Callbacks
+metrics.register_callback(function()
+    cpu_usage_gauge:set(math.random(), {app = 'tarantool'})
+end)
+
+metrics.register_callback(function()
+    http_requests_total_counter:inc(1, {method = 'POST'})
+    http_requests_total_hist:observe(math.random(1, 10))
+end) -- this functions will be automatically called before every metrics.collect()

--- a/metrics/details/init.lua
+++ b/metrics/details/init.lua
@@ -37,11 +37,13 @@ function Registry:unregister(collector)
     end
 end
 
-function Registry:collect()
+function Registry:invoke_callbacks()
     for _, registered_callback in ipairs(self.callbacks) do
         registered_callback()
     end
+end
 
+function Registry:collect()
     local result = {}
     for _, collector in pairs(self.collectors) do
         for _, obs in ipairs(collector:collect()) do

--- a/metrics/details/init.lua
+++ b/metrics/details/init.lua
@@ -22,7 +22,7 @@ end
 
 function Registry:register(collector)
     for _, c in ipairs(self.collectors) do
-        if c.name == collector.name and c.collector == collector.collector then
+        if c.name == collector.name and c.collector == collector.type then
             return
         end
     end
@@ -31,7 +31,7 @@ end
 
 function Registry:unregister(collector)
     for i, c in ipairs(self.collectors) do
-        if c.name == collector.name and c.collectors == collector.collector then
+        if c.name == collector.name and c.collectors == collector.type then
             table.remove(self.collectors, i)
         end
     end
@@ -69,9 +69,9 @@ global_metrics_registry = Registry.new()
 
 local Shared = {}
 
-function Shared.new(name, help, collector)
+function Shared.new(name, help, type)
     if not name then
-        error("Name should be set for %s", collector)
+        error("Name should be set for %s", type)
     end
 
     local obj = {}
@@ -79,7 +79,7 @@ function Shared.new(name, help, collector)
     obj.help = help or ""
     obj.observations = {}
     obj.label_pairs = {}
-    obj.collector = collector
+    obj.type = type
 
     return obj
 end
@@ -197,7 +197,7 @@ function Histogram.new(name, help, buckets)
     -- for registry
     obj.name = name
     obj.help = help or ''
-    obj.collector = 'histogram'
+    obj.type = 'histogram'
 
     -- introduce buckets
     obj.buckets = buckets or DEFAULT_BUCKETS
@@ -234,11 +234,11 @@ function Histogram:observe(num, label_pairs)
         bkt_label_pairs.le = bucket
 
         if num <= bucket then
-            self.bucket_collector:inc(1, label_pairs)
+            self.bucket_collector:inc(1, bkt_label_pairs)
         else
             -- all buckets are needed for histogram quantile approximation
             -- this creates buckets if they were not created before
-            self.bucket_collector:inc(0, label_pairs)
+            self.bucket_collector:inc(0, bkt_label_pairs)
         end
     end
 end

--- a/metrics/details/init.lua
+++ b/metrics/details/init.lua
@@ -22,7 +22,7 @@ end
 
 function Registry:register(collector)
     for _, c in ipairs(self.collectors) do
-        if c.name == collector.name and c.collector == collector.type then
+        if c.name == collector.name and c.kind == collector.kind then
             return
         end
     end
@@ -31,7 +31,7 @@ end
 
 function Registry:unregister(collector)
     for i, c in ipairs(self.collectors) do
-        if c.name == collector.name and c.collectors == collector.type then
+        if c.name == collector.name and c.kind == collector.kind then
             table.remove(self.collectors, i)
         end
     end
@@ -69,9 +69,9 @@ global_metrics_registry = Registry.new()
 
 local Shared = {}
 
-function Shared.new(name, help, type)
+function Shared.new(name, help, kind)
     if not name then
-        error("Name should be set for %s", type)
+        error("Name should be set for %s", kind)
     end
 
     local obj = {}
@@ -79,7 +79,7 @@ function Shared.new(name, help, type)
     obj.help = help or ""
     obj.observations = {}
     obj.label_pairs = {}
-    obj.type = type
+    obj.kind = kind
 
     return obj
 end
@@ -197,7 +197,7 @@ function Histogram.new(name, help, buckets)
     -- for registry
     obj.name = name
     obj.help = help or ''
-    obj.type = 'histogram'
+    obj.kind = 'histogram'
 
     -- introduce buckets
     obj.buckets = buckets or DEFAULT_BUCKETS

--- a/metrics/details/init.lua
+++ b/metrics/details/init.lua
@@ -142,9 +142,10 @@ Counter.__index = Counter
 
 function Counter.new(name, help, opts)
     local opts = opts or {}
+    opts.do_register = opts.do_register or true
 
     local obj = Shared.new(name, help, 'counter')
-    if not opts.dont_register then
+    if opts.do_register then
         global_metrics_registry:register(obj)
     end
 
@@ -208,13 +209,13 @@ function Histogram.new(name, help, buckets)
 
     -- create counters
     obj.count_collector = Counter.new(
-        name .. '_count', help, {dont_register = true}
+        name .. '_count', help, {do_register = false}
     )
     obj.sum_collector = Counter.new(
-        name .. '_sum', help, {dont_register = true}
+        name .. '_sum', help, {do_register = false}
     )
     obj.bucket_collector = Counter.new(
-        name .. '_bucket', help, {dont_register = true}
+        name .. '_bucket', help, {do_register = false}
     )
 
     -- register

--- a/metrics/plugins/README.md
+++ b/metrics/plugins/README.md
@@ -7,6 +7,7 @@ If you want to use another DB to store metrics data, you can use appropriate exp
 ## Avaliable Plugins
 
 - [Graphite](./graphite/README.md)
+- [Prometheus](./prometheus/README.md)
 
 
 ## How To Write Your Custom Plugin?

--- a/metrics/plugins/README.md
+++ b/metrics/plugins/README.md
@@ -10,6 +10,21 @@ If you want to use another DB to store metrics data, you can use appropriate exp
 
 
 ## How To Write Your Custom Plugin?
+Inside your main export function:
 
-If you want to write your custom export plugin you can use `metrics.collect()` function there.
-It returns all observations for all collectors registered via metrics client.
+```lua
+-- Invoke all callbacks registered via `metrics.register_callback(<callback-function>)`.
+metrics.invoke_callbacks()
+
+-- Loop over collectors
+for _, c in pairs(metrics.collectors()) do
+    ...
+
+    -- Loop over instant observations in collector.
+    for _, obs in pairs(c:collect()) do
+        -- Export observation `obs`
+        ...
+    end
+
+end
+```

--- a/metrics/plugins/graphite/init.lua
+++ b/metrics/plugins/graphite/init.lua
@@ -38,6 +38,7 @@ local function graphite_worker(opts)
     fiber.name('metrics_graphite_worker')
 
     while true do
+        metrics.invoke_callbacks()
         for _, c in pairs(metrics.collectors()) do
             for _, obs in ipairs(c:collect()) do
                 local data = format_observation(opts.prefix, obs)

--- a/metrics/plugins/graphite/init.lua
+++ b/metrics/plugins/graphite/init.lua
@@ -38,13 +38,14 @@ local function graphite_worker(opts)
     fiber.name('metrics_graphite_worker')
 
     while true do
-        local observations = metrics.collect()
-        for _, obs in ipairs(observations) do
-            local data = format_observation(opts.prefix, obs)
-            local numbytes = opts.sock:sendto(opts.host, opts.port, data)
-            if numbytes == nil then
-                log.error('Error while sending to host %s port %s data %s',
-                    opts.host, opts.port, data)
+        for _, c in pairs(metrics.collectors()) do
+            for _, obs in ipairs(c:collect()) do
+                local data = format_observation(opts.prefix, obs)
+                local numbytes = opts.sock:sendto(opts.host, opts.port, data)
+                if numbytes == nil then
+                    log.error('Error while sending to host %s port %s data %s',
+                              opts.host, opts.port, data)
+                end
             end
         end
 

--- a/metrics/plugins/prometheus/README.md
+++ b/metrics/plugins/prometheus/README.md
@@ -1,0 +1,27 @@
+## Prometheus
+
+Plugin to collect metrics and send them to Prometheus server.
+
+### API
+
+Import Prometheus Plugin:
+
+```lua
+local prometheus = require('metrics.plugins.prometheus')
+```
+
+#### `prometheus.collect_http()`
+Returns:
+```lua
+{
+    status = <http-status>,
+    headers = <headers>,
+    body = <body>,
+}
+```
+To be used in Tarantool `http.server` as follows:
+```lua
+local httpd = require('http.server').new(...)
+...
+httpd:route( { path = '/metrics' }, prometheus.collect_http)
+```

--- a/metrics/plugins/prometheus/README.md
+++ b/metrics/plugins/prometheus/README.md
@@ -11,10 +11,11 @@ local prometheus = require('metrics.plugins.prometheus')
 ```
 
 #### `prometheus.collect_http()`
+See [Prometheus Exposition Format](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md) for details on `<body>` and `<headers>`.
 Returns:
 ```lua
 {
-    status = <http-status>,
+    status = 200,
     headers = <headers>,
     body = <body>,
 }

--- a/metrics/plugins/prometheus/init.lua
+++ b/metrics/plugins/prometheus/init.lua
@@ -10,11 +10,11 @@ local function escape(str)
         :gsub('"', '\\"')
 end
 
-local function pickle_name(name)
+local function serialize_name(name)
     return escape(name)
 end
 
-local function pickle_label_pairs(label_pairs)
+local function serialize_label_pairs(label_pairs)
     if next(label_pairs) == nil then
         return ''
     end
@@ -29,7 +29,7 @@ local function pickle_label_pairs(label_pairs)
     return string.format('{%s}', enumerated_via_comma)
 end
 
-local function pickle_value(value)
+local function serialize_value(value)
     if value == metrics.INF then
         return '+Inf'
     elseif value == -metrics.INF then
@@ -41,16 +41,16 @@ local function pickle_value(value)
     end
 end
 
-local function pickle_all()
+local function serialize_all()
     local parts = {}
     for _, c in pairs(metrics.collectors()) do
         table.insert(parts, "# HELP " .. c.name .. " " .. c.help)
         table.insert(parts, "# TYPE " .. c.name .. " " .. c.collector)
         for _, obs in ipairs(c:collect()) do
-            local s = pickle_name(obs.metric_name)
-                   .. pickle_label_pairs(obs.label_pairs)
+            local s = serialize_name(obs.metric_name)
+                   .. serialize_label_pairs(obs.label_pairs)
                    .. ' '
-                   .. pickle_value(obs.value)
+                   .. serialize_value(obs.value)
             table.insert(parts, s)
         end
     end
@@ -61,7 +61,7 @@ function prometheus.collect_http()
     return {
         status = 200,
         headers = { ['content-type'] = 'text/plain; charset=utf8' },
-        body = pickle_all(),
+        body = serialize_all(),
     }
 end
 

--- a/metrics/plugins/prometheus/init.lua
+++ b/metrics/plugins/prometheus/init.lua
@@ -45,7 +45,7 @@ local function collect_and_serialize()
     local parts = {}
     for _, c in pairs(metrics.collectors()) do
         table.insert(parts, string.format("# HELP %s %s", c.name, c.help))
-        table.insert(parts, string.format("# TYPE %s %s", c.name, c.type))
+        table.insert(parts, string.format("# TYPE %s %s", c.name, c.kind))
         for _, obs in ipairs(c:collect()) do
             local s = string.format('%s%s %s',
                 serialize_name(obs.metric_name),

--- a/metrics/plugins/prometheus/init.lua
+++ b/metrics/plugins/prometheus/init.lua
@@ -45,7 +45,7 @@ local function collect_and_serialize()
     local parts = {}
     for _, c in pairs(metrics.collectors()) do
         table.insert(parts, string.format("# HELP %s %s", c.name, c.help))
-        table.insert(parts, string.format("# TYPE %s %s", c.name, c.collector))
+        table.insert(parts, string.format("# TYPE %s %s", c.name, c.type))
         for _, obs in ipairs(c:collect()) do
             local s = string.format('%s%s %s',
                 serialize_name(obs.metric_name),

--- a/metrics/plugins/prometheus/init.lua
+++ b/metrics/plugins/prometheus/init.lua
@@ -1,0 +1,68 @@
+local metrics = require('metrics')
+require('checks')
+
+local prometheus = {}
+
+local function escape(str)
+    return str
+        :gsub("\\", "\\\\")
+        :gsub("\n", "\\n")
+        :gsub('"', '\\"')
+end
+
+local function pickle_name(name)
+    return escape(name)
+end
+
+local function pickle_label_pairs(label_pairs)
+    if next(label_pairs) == nil then
+        return ''
+    end
+
+    local parts = {}
+    for name, value in pairs(label_pairs) do
+        local s = tostring(name) .. '=' .. escape(tostring(value))
+        table.insert(parts, s)
+    end
+
+    local enumerated_via_comma = table.concat(parts, ',')
+    return string.format('{%s}', enumerated_via_comma)
+end
+
+local function pickle_value(value)
+    if value == metrics.INF then
+        return '+Inf'
+    elseif value == -metrics.INF then
+        return '-Inf'
+    elseif value ~= value then
+        return 'Nan'
+    else
+        return escape(tostring(value))
+    end
+end
+
+local function pickle_all()
+    local parts = {}
+    for _, c in pairs(metrics.collectors()) do
+        table.insert(parts, "# HELP " .. c.name .. " " .. c.help)
+        table.insert(parts, "# TYPE " .. c.name .. " " .. c.collector)
+        for _, obs in ipairs(c:collect()) do
+            local s = pickle_name(obs.metric_name)
+                   .. pickle_label_pairs(obs.label_pairs)
+                   .. ' '
+                   .. pickle_value(obs.value)
+            table.insert(parts, s)
+        end
+    end
+    return table.concat(parts, '\n')
+end
+
+function prometheus.collect_http()
+    return {
+        status = 200,
+        headers = { ['content-type'] = 'text/plain; charset=utf8' },
+        body = pickle_all(),
+    }
+end
+
+return prometheus

--- a/metrics/plugins/prometheus/init.lua
+++ b/metrics/plugins/prometheus/init.lua
@@ -14,6 +14,18 @@ local function serialize_name(name)
     return escape(name)
 end
 
+local function serialize_value(value)
+    if value == metrics.INF then
+        return '+Inf'
+    elseif value == -metrics.INF then
+        return '-Inf'
+    elseif value ~= value then
+        return 'Nan'
+    else
+        return escape(tostring(value))
+    end
+end
+
 local function serialize_label_pairs(label_pairs)
     if next(label_pairs) == nil then
         return ''
@@ -21,7 +33,8 @@ local function serialize_label_pairs(label_pairs)
 
     local parts = {}
     for name, value in pairs(label_pairs) do
-        local s = string.format('%s=%s', tostring(name), escape(tostring(value)))
+        local s = string.format('%s="%s"',
+            serialize_value(name), serialize_value(value))
         table.insert(parts, s)
     end
 

--- a/metrics/plugins/prometheus/init.lua
+++ b/metrics/plugins/prometheus/init.lua
@@ -55,6 +55,7 @@ local function serialize_value(value)
 end
 
 local function collect_and_serialize()
+    metrics.invoke_callbacks()
     local parts = {}
     for _, c in pairs(metrics.collectors()) do
         table.insert(parts, string.format("# HELP %s %s", c.name, c.help))


### PR DESCRIPTION
Implements Prometheus Exporter for `tarantool/metrics`.

New public function `metrics.collectors()` was created in order to export histograms correctly. This is because Prometheus HTTP payload requires additional metainfo on collector types in addition to raw observations.

`metrics.collectors()` returns a set of collectors.

[tarantool/prometheus](https://github.com/tarantool/prometheus) was used as a reference implementation.