### PR TITLE
Fix Histogram registration

### DIFF
--- a/metrics/details/init.lua
+++ b/metrics/details/init.lua
@@ -144,7 +144,9 @@ Counter.__index = Counter
 
 function Counter.new(name, help, opts)
     local opts = opts or {}
-    opts.do_register = opts.do_register or true
+    if opts.do_register == nil then
+        opts.do_register = true
+    end
 
     local obj = Shared.new(name, help, 'counter')
     if opts.do_register then


### PR DESCRIPTION
Counter.new() do_register option is always
overriden to true.

The commit fixes this by implementing
default value for boolean variable correctly.