### PR TITLE
Cache in registry metrics objects and check it before creation [Closes #27]

### DIFF
--- a/metrics/details/init.lua
+++ b/metrics/details/init.lua
@@ -23,7 +23,7 @@ end
 function Registry:is_registered(collector)
     for _, c in ipairs(self.collectors) do
         if c.name == collector.name and c.kind == collector.kind then
-            return true
+            return true, c
         end
     end
     return false
@@ -70,6 +70,15 @@ function Registry:register_callback(callback)
     if not found then
         table.insert(self.callbacks, callback)
     end
+end
+
+function Registry:instanceof(obj, mt)
+    local found, metric = self:is_registered(obj)
+    if not found then
+        metric = setmetatable(obj, mt)
+        self:register(metric)
+    end
+    return metric
 end
 
 global_metrics_registry = Registry.new()
@@ -157,9 +166,8 @@ function Counter.new(name, help, opts)
 
     local obj = Shared.new(name, help, 'counter')
     if opts.do_register then
-        global_metrics_registry:register(obj)
+        return global_metrics_registry:instanceof(obj, Counter)
     end
-
     return setmetatable(obj, Counter)
 end
 
@@ -179,9 +187,7 @@ Gauge.__index = Gauge
 
 function Gauge.new(name, help)
     local obj = Shared.new(name, help, 'gauge')
-    global_metrics_registry:register(obj)
-
-    return setmetatable(obj, Gauge)
+    return global_metrics_registry:instanceof(obj, Gauge)
 end
 
 function Gauge:inc(num, label_pairs)
@@ -230,9 +236,7 @@ function Histogram.new(name, help, buckets)
     )
 
     -- register
-    global_metrics_registry:register(obj)
-
-    return setmetatable(obj, Histogram)
+    return global_metrics_registry:instanceof(obj, Histogram)
 end
 
 function Histogram:observe(num, label_pairs)

--- a/metrics/details/init.lua
+++ b/metrics/details/init.lua
@@ -29,7 +29,14 @@ function Registry:is_registered(collector)
     return false
 end
 
+local function is_empty(str)
+    return str == nil or str == ''
+end
+
 function Registry:get_registered(collector)
+    assert(collector ~= nil, 'Collector is empty')
+    assert(not is_empty(collector.name), "Collector''s name is empty")
+    assert(not is_empty(collector.kind), "Collector''s kind is empty")
     for _, c in ipairs(self.collectors) do
         if c.name == collector.name and c.kind == collector.kind then
             return c

--- a/metrics/details/init.lua
+++ b/metrics/details/init.lua
@@ -23,10 +23,19 @@ end
 function Registry:is_registered(collector)
     for _, c in ipairs(self.collectors) do
         if c.name == collector.name and c.kind == collector.kind then
-            return true, c
+            return true
         end
     end
     return false
+end
+
+function Registry:get_registered(collector)
+    for _, c in ipairs(self.collectors) do
+        if c.name == collector.name and c.kind == collector.kind then
+            return c
+        end
+    end
+    return nil
 end
 
 function Registry:register(collector)
@@ -73,8 +82,8 @@ function Registry:register_callback(callback)
 end
 
 function Registry:instanceof(obj, mt)
-    local found, metric = self:is_registered(obj)
-    if not found then
+    local metric = self:get_registered(obj)
+    if metric == nil then
         metric = setmetatable(obj, mt)
         self:register(metric)
     end

--- a/test/collectors_test.lua
+++ b/test/collectors_test.lua
@@ -140,3 +140,23 @@ g.test_histogram = function()
     t.assertEquals(obs_bucket_4.value, 1, 'bucket 4 has 1 value: 3')
     t.assertEquals(obs_bucket_inf.value, 1, 'bucket +inf has 1 value: 3')
 end
+
+g.test_counter_cache = function()
+    -- delete all previous collectors
+    metrics.clear()
+    local counter_1 = metrics.counter('cnt', 'test counter')
+    local counter_2 = metrics.counter('cnt', 'test counter')
+    local counter_3 = metrics.counter('cnt2', 'another test counter')
+
+    counter_1:inc(3)
+    counter_2:inc(5)
+    counter_3:inc(7)
+
+    local collectors = metrics.collectors()
+    local observations = metrics.collect()
+    local obs = utils.find_obs('cnt', {}, observations)
+    t.assertEquals(#collectors, 2, 'counter_1 and counter_2 refer to the same object')
+    t.assertEquals(obs.value, 8, '3 + 5 = 8')
+    obs = utils.find_obs('cnt2', {}, observations)
+    t.assertEquals(obs.value, 7, 'counter_3 is the only reference to cnt2')
+end


### PR DESCRIPTION
Check if metric exists in registry cache (by its name and type) before new instance creation.