### PR TITLE
Add optional global labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ by specifying conditions on label values. In above example, we could derive a ti
   1. total # of requests over time with method = "POST" (and any status).
   2. total # of requests over time with status = 500 (and any method).
 
+You can also set global labels by calling `metrics.set_global_labels({ label = value, ...})`.
+It will add some labels to every observation.
+Labels table is validated before use: label key must be a string. (Throws error otherwise.)
+You can change global labels along the way.
+Global labels never overwrite local (passed as function argument) ones.
+
 ------------------------------------------------------------------------
 
 

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -56,6 +56,22 @@ end
 local function clear()
     global_metrics_registry.collectors = {}
     global_metrics_registry.callbacks = {}
+    global_metrics_registry.label_pairs = {}
+end
+
+local function set_global_labels(label_pairs)
+    checks('?table')
+
+    label_pairs = label_pairs or {}
+
+    -- Verify label table
+    for k, _ in pairs(label_pairs) do
+        if type(k) ~= 'string' then
+            error(("bad label key (string expected, got %s)"):type(k))
+        end
+    end
+
+    global_metrics_registry:set_labels(label_pairs)
 end
 
 return {
@@ -70,6 +86,7 @@ return {
     collectors = collectors,
     register_callback = register_callback,
     invoke_callbacks = invoke_callbacks,
+    set_global_labels = set_global_labels,
     enable_default_metrics = function()
         return require('metrics.default_metrics.tarantool').enable()
     end,

--- a/metrics/plugins/json/init.lua
+++ b/metrics/plugins/json/init.lua
@@ -2,7 +2,7 @@ local metrics = require('metrics')
 local json = require('json')
 local json_exporter = {}
 
-local function finite(value)  
+local function finite(value)
     if type(value) == "string" then
         value = tonumber(value)
         if value == nil then return nil end

--- a/test/collectors_test.lua
+++ b/test/collectors_test.lua
@@ -13,6 +13,11 @@ g.before_all = function()
     )
 end
 
+g.setup = function()
+    -- Delete all previous collectors and global labels
+    metrics.clear()
+end
+
 local function ensure_throws(desc, fun)
    local ok, _ = pcall(fun)
    t.assertTrue(not ok, desc .. ' throws')
@@ -26,9 +31,6 @@ g.test_counter = function()
     ensure_throws('metrics.counter() w/ name as number', function()
         metrics.counter(2)
     end)
-
-    -- delete all previous collectors
-    metrics.clear()
 
     local c = metrics.counter('cnt', 'some counter')
 
@@ -64,9 +66,6 @@ g.test_gauge = function()
         metrics.gauge(2)
     end)
 
-    -- delete all previous collectors
-    metrics.clear()
-
     local gauge = metrics.gauge('gauge', 'some gauge')
 
     gauge:inc(3)
@@ -98,9 +97,6 @@ g.test_histogram = function()
     ensure_throws('metrics.histogram() w/ name as number', function()
         metrics.histogram(2)
     end)
-
-    -- delete all previous collectors
-    metrics.clear()
 
     local h = metrics.histogram('hist', 'some histogram', {2, 4})
 
@@ -142,8 +138,6 @@ g.test_histogram = function()
 end
 
 g.test_counter_cache = function()
-    -- delete all previous collectors
-    metrics.clear()
     local counter_1 = metrics.counter('cnt', 'test counter')
     local counter_2 = metrics.counter('cnt', 'test counter')
     local counter_3 = metrics.counter('cnt2', 'another test counter')
@@ -159,4 +153,115 @@ g.test_counter_cache = function()
     t.assertEquals(obs.value, 8, '3 + 5 = 8')
     obs = utils.find_obs('cnt2', {}, observations)
     t.assertEquals(obs.value, 7, 'counter_3 is the only reference to cnt2')
+end
+
+g.test_global_labels = function()
+    --- Incorrect global label
+    ensure_throws("label key must be a string", function()
+        metrics.set_global_labels({ [2] = 'value' })
+    end)
+
+    --- Set correct global label
+    metrics.set_global_labels({ alias = 'my_instance' })
+
+    --- Ensure global label appends to counter observations
+    local counter = metrics.counter('counter', 'test counter')
+
+    -- Make some observation
+    counter:inc(3)
+
+    -- Collect metrics and check their labels
+    local observations = metrics.collect()
+    local obs_cnt = utils.find_obs('counter', { alias = "my_instance" }, observations)
+    t.assertEquals(obs_cnt.value, 3, "observation has global label")
+
+
+    --- Ensure global label appends to gauge observations
+    local gauge = metrics.gauge('gauge', 'test gauge')
+
+    -- Make some observation
+    gauge:set(0.42)
+
+    -- Collect metrics and check their labels
+    observations = metrics.collect()
+    local obs_gauge = utils.find_obs('gauge', { alias = 'my_instance' }, observations)
+    t.assertEquals(obs_gauge.value, 0.42, "observation has global label")
+
+
+    --- Ensure global label appends to every histogram observation
+    local hist = metrics.histogram('hist', 'test histogram', {2})
+
+    -- Make some observation
+    hist:observe(3)
+
+    -- Collect metrics and check their labels
+    observations = metrics.collect()
+
+    local obs_sum = utils.find_obs('hist_sum', { alias = "my_instance" }, observations)
+    t.assertEquals(obs_sum.value, 3, "only one observed value 3; observation has global label")
+
+    local obs_count = utils.find_obs('hist_count', { alias = "my_instance" }, observations)
+    t.assertEquals(obs_count.value, 1, "1 observed value; observation has global label")
+
+    local obs_bucket_2 = utils.find_obs('hist_bucket',
+        { le = 2, alias = "my_instance" }, observations)
+    t.assertEquals(obs_bucket_2.value, 0, "bucket 2 has no values; observation has global label")
+
+    local obs_bucket_inf = utils.find_obs('hist_bucket',
+        { le = metrics.INF, alias = "my_instance" }, observations)
+    t.assertEquals(obs_bucket_inf.value, 1, "bucket +inf has 1 value: 3; observation has global label")
+
+
+    --- Ensure global label merges with argument labels
+    local gauge_2 = metrics.gauge('gauge 2', 'test gauge 2')
+
+    -- Make some observation with label
+    gauge_2:set(0.43, { mylabel = 'my observation' })
+
+    -- Collect metrics and check their labels
+    observations = metrics.collect()
+
+    local obs_gauge_2 = utils.find_obs('gauge 2', { alias = 'my_instance', mylabel = 'my observation' }, observations)
+    t.assertEquals(obs_gauge_2.value, 0.43, "observation has global label")
+
+
+    --- Ensure label passed as argument overwrites global one
+    local gauge_3 = metrics.gauge('gauge 3', 'test gauge 3')
+
+    -- Make some observation with "alias" label key
+    -- metrics.set_global_labels({ alias = 'my_instance' })
+    gauge_3:set(0.44, { alias = 'gauge alias' })
+
+    -- Collect metrics and check their labels
+    observations = metrics.collect()
+    local obs_gauge_3 = utils.find_obs('gauge 3', { alias = 'gauge alias' }, observations)
+    t.assertEquals(obs_gauge_3.value, 0.44, "global label has not overwritten local one")
+
+
+    --- Ensure we can change global labels along the way
+    local hist_2 = metrics.histogram('hist_2', 'test histogram 2', {3})
+
+    -- Make some observation
+    hist_2:observe(2)
+    -- Change global labels
+    metrics.set_global_labels({ alias = 'another alias', nlabel = 3 })
+
+    -- Collect metrics and check their labels
+    observations = metrics.collect()
+
+    local obs_sum_hist_2 = utils.find_obs('hist_2_sum',
+        { alias = 'another alias', nlabel = 3 }, observations)
+    t.assertEquals(obs_sum_hist_2.value, 2, "only one observed value 2; observation global label has changed")
+
+    local obs_sum_count_2 = utils.find_obs('hist_2_count',
+        { alias = 'another alias', nlabel = 3 }, observations)
+    t.assertEquals(obs_sum_count_2.value, 1, "1 observed value; observation global label has changed")
+
+    local obs_bucket_3_hist_2 = utils.find_obs('hist_2_bucket',
+        { le = 3, alias = 'another alias', nlabel = 3 }, observations)
+    t.assertEquals(obs_bucket_3_hist_2.value, 1, "bucket 3 has 1 value: 2; observation global label has changed")
+
+    local obs_bucket_inf_hist_2 = utils.find_obs('hist_2_bucket',
+        { le = metrics.INF, alias = 'another alias', nlabel = 3 }, observations)
+    t.assertEquals(obs_bucket_inf_hist_2.value, 1, "bucket +inf has 1 value: 2; observation global label has changed")
 end

--- a/test/json_plugin_test.lua
+++ b/test/json_plugin_test.lua
@@ -16,9 +16,12 @@ g.before_all = function()
     )
 end
 
-g.test_infinite_value_serialization = function()
+g.setup = function()
+    -- Delete all previous collectors and global labels
     metrics.clear()
+end
 
+g.test_infinite_value_serialization = function()
     local test_nan = metrics.gauge('test_nan')
     local test_inf = metrics.gauge('test_inf')
 
@@ -42,8 +45,6 @@ g.test_infinite_value_serialization = function()
 end
 
 g.test_number_value_serialization = function()
-    metrics.clear()
-
     local test_num_float = metrics.gauge('number_float')
     local test_num_int = metrics.counter('number_int')
 
@@ -65,7 +66,6 @@ g.test_number_value_serialization = function()
 end
 
 g.test_histogram = function()
-    metrics.clear()
     local h = metrics.histogram('hist', 'some histogram', {2, 4})
 
     h:observe(3)


### PR DESCRIPTION
Add optional global labels to metrics. (Solves #30 issue.)
Solution is driver-independent and can be used with any custom driver.

Global labels can be set by calling 
```
metrics.set_global_labels({ label = value, ...}).
```
Labels table is validated before use: label key must be a string. (Throws error otherwise.)
Global labels are stored in `global_metrics_registry` as `global_metrics_registry.label_pairs`. Global labels append to every observation on `collector:collect()` call. (Refer to #30 third solution.) Global labels never overwrite local (passed as function argument) ones.
`metrics.clear()` call also cleans global labels.