### PR TITLE
Update luatest to 0.4.0, fix global labels verification error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ _test: &test
     - sudo apt-get -y update
     - sudo apt-get install -y tarantool tarantool-dev
     - tarantoolctl rocks make
-    - tarantoolctl rocks install luatest 0.2.2
+    - tarantoolctl rocks install luatest 0.4.0
   script: .rocks/bin/luatest
 
 _deploy: &deploy

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -67,7 +67,7 @@ local function set_global_labels(label_pairs)
     -- Verify label table
     for k, _ in pairs(label_pairs) do
         if type(k) ~= 'string' then
-            error(("bad label key (string expected, got %s)"):type(k))
+            error(("bad label key (string expected, got %s)"):format(type(k)))
         end
     end
 

--- a/test/collectors_test.lua
+++ b/test/collectors_test.lua
@@ -6,29 +6,27 @@ local g = t.group('collectors')
 local metrics = require('metrics')
 local utils = require('test.utils')
 
-g.before_all = function()
+g.before_all(function()
     box.cfg{}
     box.schema.user.grant(
         'guest', 'read,write,execute', 'universe', nil, {if_not_exists = true}
     )
-end
 
-g.setup = function()
     -- Delete all previous collectors and global labels
     metrics.clear()
-end
+end)
 
-local function ensure_throws(desc, fun)
-   local ok, _ = pcall(fun)
-   t.assertTrue(not ok, desc .. ' throws')
-end
+g.after_each(function()
+    -- Delete all collectors and global labels
+    metrics.clear()
+end)
 
 g.test_counter = function()
-    ensure_throws('metrics.counter() w/o parameters', function()
+    t.assert_error_msg_contains("bad argument #1 to counter (string expected, got nil)", function()
         metrics.counter()
     end)
 
-    ensure_throws('metrics.counter() w/ name as number', function()
+    t.assert_error_msg_contains("bad argument #1 to counter (string expected, got number)", function()
         metrics.counter(2)
     end)
 
@@ -40,29 +38,27 @@ g.test_counter = function()
     local collectors = metrics.collectors()
     local observations = metrics.collect()
     local obs = utils.find_obs('cnt', {}, observations)
-    t.assertEquals(#collectors, 1, 'counter seen as only collector')
-    t.assertEquals(obs.value, 8, '3 + 5 = 8 (via metrics.collectors())')
+    t.assert_equals(#collectors, 1, 'counter seen as only collector')
+    t.assert_equals(obs.value, 8, '3 + 5 = 8 (via metrics.collectors())')
 
-    t.assertEquals(c:collect()[1].value, 8, '3 + 5 = 8')
+    t.assert_equals(c:collect()[1].value, 8, '3 + 5 = 8')
 
-    ensure_throws('counter:inc(<negative value>)', function()
+    t.assert_error_msg_contains("Counter increment should not be negative", function()
         c:inc(-1)
     end)
-    ensure_throws('counter:dec(...)', function()
-        c:dec(1)
-    end)
+
+    t.assert_equals(c.dec, nil, "Counter doesn't have 'decrease' method")
 
     c:inc(0)
-
-    t.assertEquals(c:collect()[1].value, 8, '8 + 0 = 8')
+    t.assert_equals(c:collect()[1].value, 8, '8 + 0 = 8')
 end
 
 g.test_gauge = function()
-    ensure_throws('metrics.gauge() w/o parameters', function()
+    t.assert_error_msg_contains("bad argument #1 to gauge (string expected, got nil)", function()
         metrics.gauge()
     end)
 
-    ensure_throws('metrics.gauge() w/ name as number', function()
+    t.assert_error_msg_contains("bad argument #1 to gauge (string expected, got number)", function()
         metrics.gauge(2)
     end)
 
@@ -74,27 +70,27 @@ g.test_gauge = function()
     local collectors = metrics.collectors()
     local observations = metrics.collect()
     local obs = utils.find_obs('gauge', {}, observations)
-    t.assertEquals(#collectors, 1, 'gauge seen as only collector')
-    t.assertEquals(obs.value, -2, '3 - 5 = -2 (via metrics.collectors())')
+    t.assert_equals(#collectors, 1, 'gauge seen as only collector')
+    t.assert_equals(obs.value, -2, '3 - 5 = -2 (via metrics.collectors())')
 
-    t.assertEquals(gauge:collect()[1].value, -2, '3 - 5 = -2')
+    t.assert_equals(gauge:collect()[1].value, -2, '3 - 5 = -2')
 
     gauge:set(-8)
 
-    t.assertEquals(gauge:collect()[1].value, -8, 'after set(-8) = -8')
+    t.assert_equals(gauge:collect()[1].value, -8, 'after set(-8) = -8')
 
     gauge:inc(-1)
     gauge:dec(-2)
 
-    t.assertEquals(gauge:collect()[1].value, -7, '-8 + (-1) - (-2)')
+    t.assert_equals(gauge:collect()[1].value, -7, '-8 + (-1) - (-2)')
 end
 
 g.test_histogram = function()
-    ensure_throws('metrics.histogram() w/o parameters', function()
+    t.assert_error_msg_contains("bad argument #1 to histogram (string expected, got nil)", function()
         metrics.histogram()
     end)
 
-    ensure_throws('metrics.histogram() w/ name as number', function()
+    t.assert_error_msg_contains("bad argument #1 to histogram (string expected, got number)", function()
         metrics.histogram(2)
     end)
 
@@ -104,37 +100,37 @@ g.test_histogram = function()
     h:observe(5)
 
     local collectors = metrics.collectors()
-    t.assertEquals(#collectors, 1, 'histogram seen as only 1 collector')
+    t.assert_equals(#collectors, 1, 'histogram seen as only 1 collector')
     local observations = metrics.collect()
     local obs_sum = utils.find_obs('hist_sum', {}, observations)
     local obs_count = utils.find_obs('hist_count', {}, observations)
-    local obs_bucket_2 = utils.find_obs('hist_bucket', {le = 2}, observations)
-    local obs_bucket_4 = utils.find_obs('hist_bucket', {le = 4}, observations)
-    local obs_bucket_inf = utils.find_obs('hist_bucket', {le = metrics.INF}, observations)
-    t.assertEquals(#observations, 5, '<name>_sum, <name>_count, and <name>_bucket with 3 labelpairs')
-    t.assertEquals(obs_sum.value, 8, '3 + 5 = 8')
-    t.assertEquals(obs_count.value, 2, '2 observed values')
-    t.assertEquals(obs_bucket_2.value, 0, 'bucket 2 has no values')
-    t.assertEquals(obs_bucket_4.value, 1, 'bucket 4 has 1 value: 3')
-    t.assertEquals(obs_bucket_inf.value, 2, 'bucket +inf has 2 values: 3, 5')
+    local obs_bucket_2 = utils.find_obs('hist_bucket', { le = 2 }, observations)
+    local obs_bucket_4 = utils.find_obs('hist_bucket', { le = 4 }, observations)
+    local obs_bucket_inf = utils.find_obs('hist_bucket', { le = metrics.INF }, observations)
+    t.assert_equals(#observations, 5, '<name>_sum, <name>_count, and <name>_bucket with 3 labelpairs')
+    t.assert_equals(obs_sum.value, 8, '3 + 5 = 8')
+    t.assert_equals(obs_count.value, 2, '2 observed values')
+    t.assert_equals(obs_bucket_2.value, 0, 'bucket 2 has no values')
+    t.assert_equals(obs_bucket_4.value, 1, 'bucket 4 has 1 value: 3')
+    t.assert_equals(obs_bucket_inf.value, 2, 'bucket +inf has 2 values: 3, 5')
 
-    h:observe(3, {foo = 'bar'})
+    h:observe(3, { foo = 'bar' })
 
     collectors = metrics.collectors()
-    t.assertEquals(#collectors, 1, 'still histogram seen as only 1 collector')
+    t.assert_equals(#collectors, 1, 'still histogram seen as only 1 collector')
     observations = metrics.collect()
-    obs_sum = utils.find_obs('hist_sum', {foo = 'bar'}, observations)
-    obs_count = utils.find_obs('hist_count', {foo = 'bar'}, observations)
-    obs_bucket_2 = utils.find_obs('hist_bucket', {le = 2, foo = 'bar'}, observations)
-    obs_bucket_4 = utils.find_obs('hist_bucket', {le = 4, foo = 'bar'}, observations)
-    obs_bucket_inf = utils.find_obs('hist_bucket', {le = metrics.INF, foo = 'bar'}, observations)
+    obs_sum = utils.find_obs('hist_sum', { foo = 'bar' }, observations)
+    obs_count = utils.find_obs('hist_count', { foo = 'bar' }, observations)
+    obs_bucket_2 = utils.find_obs('hist_bucket', { le = 2, foo = 'bar' }, observations)
+    obs_bucket_4 = utils.find_obs('hist_bucket', { le = 4, foo = 'bar' }, observations)
+    obs_bucket_inf = utils.find_obs('hist_bucket', { le = metrics.INF, foo = 'bar' }, observations)
 
-    t.assertEquals(#observations, 10, '+ <name>_sum, <name>_count, and <name>_bucket with 3 labelpairs')
-    t.assertEquals(obs_sum.value, 3, '3 = 3')
-    t.assertEquals(obs_count.value, 1, '1 observed values')
-    t.assertEquals(obs_bucket_2.value, 0, 'bucket 2 has no values')
-    t.assertEquals(obs_bucket_4.value, 1, 'bucket 4 has 1 value: 3')
-    t.assertEquals(obs_bucket_inf.value, 1, 'bucket +inf has 1 value: 3')
+    t.assert_equals(#observations, 10, '+ <name>_sum, <name>_count, and <name>_bucket with 3 labelpairs')
+    t.assert_equals(obs_sum.value, 3, '3 = 3')
+    t.assert_equals(obs_count.value, 1, '1 observed values')
+    t.assert_equals(obs_bucket_2.value, 0, 'bucket 2 has no values')
+    t.assert_equals(obs_bucket_4.value, 1, 'bucket 4 has 1 value: 3')
+    t.assert_equals(obs_bucket_inf.value, 1, 'bucket +inf has 1 value: 3')
 end
 
 g.test_counter_cache = function()
@@ -149,15 +145,14 @@ g.test_counter_cache = function()
     local collectors = metrics.collectors()
     local observations = metrics.collect()
     local obs = utils.find_obs('cnt', {}, observations)
-    t.assertEquals(#collectors, 2, 'counter_1 and counter_2 refer to the same object')
-    t.assertEquals(obs.value, 8, '3 + 5 = 8')
+    t.assert_equals(#collectors, 2, 'counter_1 and counter_2 refer to the same object')
+    t.assert_equals(obs.value, 8, '3 + 5 = 8')
     obs = utils.find_obs('cnt2', {}, observations)
-    t.assertEquals(obs.value, 7, 'counter_3 is the only reference to cnt2')
+    t.assert_equals(obs.value, 7, 'counter_3 is the only reference to cnt2')
 end
 
 g.test_global_labels = function()
-    --- Incorrect global label
-    ensure_throws("label key must be a string", function()
+    t.assert_error_msg_contains("bad label key (string expected, got number)", function()
         metrics.set_global_labels({ [2] = 'value' })
     end)
 
@@ -173,7 +168,7 @@ g.test_global_labels = function()
     -- Collect metrics and check their labels
     local observations = metrics.collect()
     local obs_cnt = utils.find_obs('counter', { alias = "my_instance" }, observations)
-    t.assertEquals(obs_cnt.value, 3, "observation has global label")
+    t.assert_equals(obs_cnt.value, 3, "observation has global label")
 
 
     --- Ensure global label appends to gauge observations
@@ -185,7 +180,7 @@ g.test_global_labels = function()
     -- Collect metrics and check their labels
     observations = metrics.collect()
     local obs_gauge = utils.find_obs('gauge', { alias = 'my_instance' }, observations)
-    t.assertEquals(obs_gauge.value, 0.42, "observation has global label")
+    t.assert_equals(obs_gauge.value, 0.42, "observation has global label")
 
 
     --- Ensure global label appends to every histogram observation
@@ -198,18 +193,18 @@ g.test_global_labels = function()
     observations = metrics.collect()
 
     local obs_sum = utils.find_obs('hist_sum', { alias = "my_instance" }, observations)
-    t.assertEquals(obs_sum.value, 3, "only one observed value 3; observation has global label")
+    t.assert_equals(obs_sum.value, 3, "only one observed value 3; observation has global label")
 
     local obs_count = utils.find_obs('hist_count', { alias = "my_instance" }, observations)
-    t.assertEquals(obs_count.value, 1, "1 observed value; observation has global label")
+    t.assert_equals(obs_count.value, 1, "1 observed value; observation has global label")
 
     local obs_bucket_2 = utils.find_obs('hist_bucket',
         { le = 2, alias = "my_instance" }, observations)
-    t.assertEquals(obs_bucket_2.value, 0, "bucket 2 has no values; observation has global label")
+    t.assert_equals(obs_bucket_2.value, 0, "bucket 2 has no values; observation has global label")
 
     local obs_bucket_inf = utils.find_obs('hist_bucket',
         { le = metrics.INF, alias = "my_instance" }, observations)
-    t.assertEquals(obs_bucket_inf.value, 1, "bucket +inf has 1 value: 3; observation has global label")
+    t.assert_equals(obs_bucket_inf.value, 1, "bucket +inf has 1 value: 3; observation has global label")
 
 
     --- Ensure global label merges with argument labels
@@ -222,7 +217,7 @@ g.test_global_labels = function()
     observations = metrics.collect()
 
     local obs_gauge_2 = utils.find_obs('gauge 2', { alias = 'my_instance', mylabel = 'my observation' }, observations)
-    t.assertEquals(obs_gauge_2.value, 0.43, "observation has global label")
+    t.assert_equals(obs_gauge_2.value, 0.43, "observation has global label")
 
 
     --- Ensure label passed as argument overwrites global one
@@ -235,7 +230,7 @@ g.test_global_labels = function()
     -- Collect metrics and check their labels
     observations = metrics.collect()
     local obs_gauge_3 = utils.find_obs('gauge 3', { alias = 'gauge alias' }, observations)
-    t.assertEquals(obs_gauge_3.value, 0.44, "global label has not overwritten local one")
+    t.assert_equals(obs_gauge_3.value, 0.44, "global label has not overwritten local one")
 
 
     --- Ensure we can change global labels along the way
@@ -251,17 +246,17 @@ g.test_global_labels = function()
 
     local obs_sum_hist_2 = utils.find_obs('hist_2_sum',
         { alias = 'another alias', nlabel = 3 }, observations)
-    t.assertEquals(obs_sum_hist_2.value, 2, "only one observed value 2; observation global label has changed")
+    t.assert_equals(obs_sum_hist_2.value, 2, "only one observed value 2; observation global label has changed")
 
     local obs_sum_count_2 = utils.find_obs('hist_2_count',
         { alias = 'another alias', nlabel = 3 }, observations)
-    t.assertEquals(obs_sum_count_2.value, 1, "1 observed value; observation global label has changed")
+    t.assert_equals(obs_sum_count_2.value, 1, "1 observed value; observation global label has changed")
 
     local obs_bucket_3_hist_2 = utils.find_obs('hist_2_bucket',
         { le = 3, alias = 'another alias', nlabel = 3 }, observations)
-    t.assertEquals(obs_bucket_3_hist_2.value, 1, "bucket 3 has 1 value: 2; observation global label has changed")
+    t.assert_equals(obs_bucket_3_hist_2.value, 1, "bucket 3 has 1 value: 2; observation global label has changed")
 
     local obs_bucket_inf_hist_2 = utils.find_obs('hist_2_bucket',
         { le = metrics.INF, alias = 'another alias', nlabel = 3 }, observations)
-    t.assertEquals(obs_bucket_inf_hist_2.value, 1, "bucket +inf has 1 value: 2; observation global label has changed")
+    t.assert_equals(obs_bucket_inf_hist_2.value, 1, "bucket +inf has 1 value: 2; observation global label has changed")
 end

--- a/test/json_plugin_test.lua
+++ b/test/json_plugin_test.lua
@@ -6,20 +6,22 @@ local g = t.group('json_plugin')
 local json_exporter = require('metrics.plugins.json')
 local metrics = require('metrics')
 local json = require('json')
-local tap = require('tap')
 local utils = require('test.utils')
 
-g.before_all = function()
+g.before_all(function()
     box.cfg{}
     box.schema.user.grant(
         'guest', 'read,write,execute', 'universe', nil, {if_not_exists = true}
     )
-end
 
-g.setup = function()
     -- Delete all previous collectors and global labels
     metrics.clear()
-end
+end)
+
+g.after_each(function()
+    -- Delete all collectors and global labels
+    metrics.clear()
+end)
 
 g.test_infinite_value_serialization = function()
     local test_nan = metrics.gauge('test_nan')
@@ -33,15 +35,15 @@ g.test_infinite_value_serialization = function()
 
     local nan_obs = utils.find_obs(
        'test_nan', { type =  tostring(metrics.NAN) }, json_metrics)
-    t.assertEquals(nan_obs.value,     tostring( metrics.NAN ), 'check  NaN')
+    t.assert_equals(nan_obs.value,     tostring( metrics.NAN ), 'check  NaN')
 
     local inf_pos_obs = utils.find_obs(
        'test_inf', { type =  tostring(metrics.INF) }, json_metrics)
-    t.assertEquals(inf_pos_obs.value, tostring( metrics.INF ), 'check  INF')
+    t.assert_equals(inf_pos_obs.value, tostring( metrics.INF ), 'check  INF')
 
     local inf_neg_obs = utils.find_obs(
        'test_inf', { type =  tostring(-metrics.INF) }, json_metrics)
-    t.assertEquals(inf_neg_obs.value, tostring(-metrics.INF ), 'check -INF')
+    t.assert_equals(inf_neg_obs.value, tostring(-metrics.INF ), 'check -INF')
 end
 
 g.test_number_value_serialization = function()
@@ -61,8 +63,8 @@ g.test_number_value_serialization = function()
         'number_int',
         { type = 'int', inf = tostring(metrics.INF) }, json_metrics)
 
-    t.assertEquals(float_obs.value, 0.333, 'check float')
-    t.assertEquals(int_obs.value, 10, 'check int')
+    t.assert_equals(float_obs.value, 0.333, 'check float')
+    t.assert_equals(int_obs.value, 10, 'check int')
 end
 
 g.test_histogram = function()
@@ -75,13 +77,13 @@ g.test_histogram = function()
 
     local obs_sum = utils.find_obs('hist_sum', {}, observations)
     local obs_count = utils.find_obs('hist_count', {}, observations)
-    local obs_bucket_2 = utils.find_obs('hist_bucket', {le = 2}, observations)
-    local obs_bucket_4 = utils.find_obs('hist_bucket', {le = 4}, observations)
-    local obs_bucket_inf = utils.find_obs('hist_bucket', {le = tostring(metrics.INF)}, observations)
-    t.assertEquals(#observations, 5, '<name>_sum, <name>_count, and <name>_bucket with 3 labelpairs')
-    t.assertEquals(obs_sum.value, 8, '3 + 5 = 8')
-    t.assertEquals(obs_count.value, 2, '2 observed values')
-    t.assertEquals(obs_bucket_2.value, 0, 'bucket 2 has no values')
-    t.assertEquals(obs_bucket_4.value, 1, 'bucket 4 has 1 value: 3')
-    t.assertEquals(obs_bucket_inf.value, 2, 'bucket +inf has 2 values: 3, 5')
+    local obs_bucket_2 = utils.find_obs('hist_bucket', { le = 2 }, observations)
+    local obs_bucket_4 = utils.find_obs('hist_bucket', { le = 4 }, observations)
+    local obs_bucket_inf = utils.find_obs('hist_bucket', { le = tostring(metrics.INF) }, observations)
+    t.assert_equals(#observations, 5, '<name>_sum, <name>_count, and <name>_bucket with 3 labelpairs')
+    t.assert_equals(obs_sum.value, 8, '3 + 5 = 8')
+    t.assert_equals(obs_count.value, 2, '2 observed values')
+    t.assert_equals(obs_bucket_2.value, 0, 'bucket 2 has no values')
+    t.assert_equals(obs_bucket_4.value, 1, 'bucket 4 has 1 value: 3')
+    t.assert_equals(obs_bucket_inf.value, 2, 'bucket +inf has 2 values: 3, 5')
 end

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -1,3 +1,5 @@
+local t = require('luatest')
+
 local utils = {}
 
 -- a < b
@@ -22,7 +24,7 @@ function utils.find_obs(metric_name, label_pairs, observations)
             return obs
         end
     end
-    assert(false, 'haven\'t found observation')
+    t.fail("haven't found observation")
 end
 
 return utils


### PR DESCRIPTION
Update luatest version to 0.4.0 in CI.

Minor test changes: use new test hooks, use snake case in asserts, improve custom `ensure_throws` with luatest embedded `assert_error_msg_contains`, reorder metrics cleanup.

Fix global labels verification error.