### PR TITLE
Remove invalid metric

### DIFF
--- a/metrics/default_metrics/tarantool/system.lua
+++ b/metrics/default_metrics/tarantool/system.lua
@@ -6,7 +6,6 @@ local function update_system_metrics()
         return
     end
 
-    utils.set_gauge('cfg_listen', 'Tarantool port', box.cfg.listen)
     utils.set_gauge('cfg_current_time', 'Tarantool cfg time', clock.time() + 0ULL)
 end
 


### PR DESCRIPTION
This pr fixes issue #34. 
It removes `cfg_listen` metric that has a string type, which is not supported by Prometheus.