### PR TITLE
replicas: add replication lag to default metrics

### DIFF
--- a/metrics/default_metrics/tarantool/info.lua
+++ b/metrics/default_metrics/tarantool/info.lua
@@ -17,9 +17,10 @@ local function update_info_metrics()
         utils.set_gauge('info_vclock_' .. k, 'VClock for ' .. k, v)
     end
 
-    for k, v in ipairs(info.replication) do
-        if v.upstream ~= nil then
-            utils.set_gauge('replication_' .. k .. '_lag', 'Replication lag for instance ' .. k, v.upstream.lag)
+    for _, replica in ipairs(info.replication) do
+        if replica.upstream ~= nil then
+            utils.set_gauge('replication_lag', 'Replication lag for instance',
+                replica.upstream.lag, {uuid = replica.uuid})
         end
     end
 end

--- a/metrics/default_metrics/tarantool/replicas.lua
+++ b/metrics/default_metrics/tarantool/replicas.lua
@@ -25,6 +25,12 @@ local function update_replicas_metrics()
                     )
                 end
             end
+
+            if v.upstream ~= nil then
+                utils.set_gauge('replication_lag_' .. k,
+                    'The time difference between the master and the replica ' .. k,
+                    v.upstream.lag)
+            end
         end
     end
 end


### PR DESCRIPTION
Backported from "prometheus" repository:
https://github.com/tarantool/prometheus/blob/5d9ef2edacb8576d99406e46dc4c79f0e7cdfc3a/tarantool-metrics.lua#L33