### PR TITLE
Add replication_state_normal gauge to default metrics

### DIFF
--- a/metrics/default_metrics/tarantool/info.lua
+++ b/metrics/default_metrics/tarantool/info.lua
@@ -17,10 +17,24 @@ local function update_info_metrics()
         utils.set_gauge('info_vclock_' .. k, 'VClock for ' .. k, v)
     end
 
+    local idle = 0
+
     for k, v in ipairs(info.replication) do
         if v.upstream ~= nil then
             utils.set_gauge('replication_' .. k .. '_lag', 'Replication lag for instance ' .. k, v.upstream.lag)
+            if v.upstream.idle > idle then
+                idle = v.upstream.idle
+            end
         end
+    end
+
+    if idle ~= 0 then
+        local replication_timeout = box.cfg.replication_timeout
+        local replication_state_normal = 0
+        if idle <= replication_timeout then
+            replication_state_normal = 1
+        end
+        utils.set_gauge('replication_state_normal', 'Is replication healthy?', replication_state_normal)
     end
 end
 


### PR DESCRIPTION
Now we have replication_lag metrics which show the time difference
between the instance and the master, but we don't have replication_state_normal
metrics which indicate that replication is healthy. So we should to make it.