### PR TITLE
Refactor collectors and registry

### DIFF
--- a/metrics/collectors/counter.lua
+++ b/metrics/collectors/counter.lua
@@ -1,30 +1,13 @@
 local Shared = require('metrics.collectors.shared')
 
-local Counter = {}
+local Counter = Shared:new_class('counter')
 Counter.__index = Counter
-
-function Counter.new(name, help, opts)
-    opts = opts or {}
-    if opts.do_register == nil then
-        opts.do_register = true
-    end
-
-    local obj = Shared.new(name, help, 'counter')
-    if opts.do_register then
-        return global_metrics_registry:instanceof(obj, Counter)
-    end
-    return setmetatable(obj, Counter)
-end
 
 function Counter:inc(num, label_pairs)
     if num and num < 0 then
         error("Counter increment should not be negative")
     end
     Shared.inc(self, num, label_pairs)
-end
-
-function Counter:collect()
-    return Shared.collect(self)
 end
 
 return Counter

--- a/metrics/collectors/gauge.lua
+++ b/metrics/collectors/gauge.lua
@@ -1,27 +1,6 @@
 local Shared = require('metrics.collectors.shared')
 
-local Gauge = {}
+local Gauge = Shared:new_class('gauge', {'inc', 'dec', 'set'})
 Gauge.__index = Gauge
-
-function Gauge.new(name, help)
-    local obj = Shared.new(name, help, 'gauge')
-    return global_metrics_registry:instanceof(obj, Gauge)
-end
-
-function Gauge:inc(num, label_pairs)
-    Shared.inc(self, num, label_pairs)
-end
-
-function Gauge:dec(num, label_pairs)
-    Shared.dec(self, num, label_pairs)
-end
-
-function Gauge:set(num, label_pairs)
-    Shared.set(self, num, label_pairs)
-end
-
-function Gauge:collect()
-    return Shared.collect(self)
-end
 
 return Gauge

--- a/metrics/collectors/histogram.lua
+++ b/metrics/collectors/histogram.lua
@@ -1,40 +1,39 @@
+local Shared = require('metrics.collectors.shared')
 local Counter = require('metrics.collectors.counter')
 
 local INF = math.huge
 local DEFAULT_BUCKETS = {.005, .01, .025, .05, .075, .1, .25, .5,
                          .75, 1.0, 2.5, 5.0, 7.5, 10.0, INF}
 
-local Histogram = {}
+local Histogram = Shared:new_class('histogram')
 Histogram.__index = Histogram
 
-function Histogram.new(name, help, buckets)
-    local obj = {}
+function Histogram.check_buckets(buckets)
+    local prev = -math.huge
+    for k, v in pairs(buckets) do
+        if type(k) ~= 'number' then return false end
+        if type(v) ~= 'number' then return false end
+        if v <= 0 then return false end
+        if prev > v then return false end
+        prev = v
+    end
+    return true
+end
 
-    -- for registry
-    obj.name = name
-    obj.help = help or ''
-    obj.kind = 'histogram'
+function Histogram:new(name, help, buckets)
+    local obj = Shared.new(self, name, help)
 
-    -- introduce buckets
     obj.buckets = buckets or DEFAULT_BUCKETS
     table.sort(obj.buckets)
     if obj.buckets[#obj.buckets] ~= INF then
         obj.buckets[#obj.buckets+1] = INF
     end
 
-    -- create counters
-    obj.count_collector = Counter.new(
-        name .. '_count', help, {do_register = false}
-    )
-    obj.sum_collector = Counter.new(
-        name .. '_sum', help, {do_register = false}
-    )
-    obj.bucket_collector = Counter.new(
-        name .. '_bucket', help, {do_register = false}
-    )
+    obj.count_collector = Counter:new(name .. '_count', help)
+    obj.sum_collector = Counter:new(name .. '_sum', help)
+    obj.bucket_collector = Counter:new(name .. '_bucket', help)
 
-    -- register
-    return global_metrics_registry:instanceof(obj, Histogram)
+    return obj
 end
 
 function Histogram:observe(num, label_pairs)
@@ -44,7 +43,7 @@ function Histogram:observe(num, label_pairs)
     self.sum_collector:inc(num, label_pairs)
 
     for _, bucket in pairs(self.buckets) do
-        local bkt_label_pairs = table.deepcopy(label_pairs) -- luacheck: ignore
+        local bkt_label_pairs = table.deepcopy(label_pairs)
         bkt_label_pairs.le = bucket
 
         if num <= bucket then

--- a/metrics/collectors/histogram.lua
+++ b/metrics/collectors/histogram.lua
@@ -36,6 +36,13 @@ function Histogram:new(name, help, buckets)
     return obj
 end
 
+function Histogram:set_registry(registry)
+    Shared.set_registry(self, registry)
+    self.count_collector:set_registry(registry)
+    self.sum_collector:set_registry(registry)
+    self.bucket_collector:set_registry(registry)
+end
+
 function Histogram:observe(num, label_pairs)
     label_pairs = label_pairs or {}
 

--- a/metrics/collectors/shared.lua
+++ b/metrics/collectors/shared.lua
@@ -2,19 +2,30 @@ local fiber = require('fiber')
 
 local Shared = {}
 
-function Shared.new(name, help, kind)
-    if not name then
-        error("Name should be set for %s", kind)
+-- Create collector class with the list of instance methods copied from
+-- this class (like an inheritance but with limited list of methods).
+function Shared:new_class(kind, method_names)
+    method_names = method_names or {}
+    -- essential methods
+    table.insert(method_names, 'new')
+    table.insert(method_names, 'collect')
+    local methods = {}
+    for _, name in pairs(method_names) do
+        methods[name] = self[name]
     end
+    return setmetatable({kind = kind}, {__index = methods})
+end
 
-    local obj = {}
-    obj.name = name
-    obj.help = help or ""
-    obj.observations = {}
-    obj.label_pairs = {}
-    obj.kind = kind
-
-    return obj
+function Shared:new(name, help)
+    if not name then
+        error("Name should be set for %s")
+    end
+    return setmetatable({
+        name = name,
+        help = help or "",
+        observations = {},
+        label_pairs = {},
+    }, self)
 end
 
 local function make_key(label_pairs)

--- a/metrics/default_metrics/tarantool/init.lua
+++ b/metrics/default_metrics/tarantool/init.lua
@@ -1,4 +1,6 @@
-local metrics = {
+local metrics = require('metrics')
+
+local default_metrics = {
     require('metrics.default_metrics.tarantool.network'),
     require('metrics.default_metrics.tarantool.operations'),
     require('metrics.default_metrics.tarantool.system'),
@@ -12,8 +14,8 @@ local metrics = {
 }
 
 local function enable()
-    for _, metric in ipairs(metrics) do
-        global_metrics_registry:register_callback(metric.update)
+    for _, metric in ipairs(default_metrics) do
+        metrics.register_callback(metric.update)
     end
 end
 

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -8,34 +8,34 @@ local Counter = require('metrics.collectors.counter')
 local Gauge = require('metrics.collectors.gauge')
 local Histogram = require('metrics.collectors.histogram')
 
-global_metrics_registry = Registry.new()
+local registry = Registry.new()
 
 local function collectors()
-    return global_metrics_registry.collectors
+    return registry.collectors
 end
 
 local function register_callback(...)
-    return global_metrics_registry:register_callback(...)
+    return registry:register_callback(...)
 end
 
 local function invoke_callbacks()
-    return global_metrics_registry:invoke_callbacks()
+    return registry:invoke_callbacks()
 end
 
 local function collect()
-    return global_metrics_registry:collect()
+    return registry:collect()
 end
 
 local function counter(name, help)
     checks('string', '?string')
 
-    return global_metrics_registry:find_or_create(Counter, name, help)
+    return registry:find_or_create(Counter, name, help)
 end
 
 local function gauge(name, help)
     checks('string', '?string')
 
-    return global_metrics_registry:find_or_create(Gauge, name, help)
+    return registry:find_or_create(Gauge, name, help)
 end
 
 local function histogram(name, help, buckets)
@@ -44,13 +44,13 @@ local function histogram(name, help, buckets)
         error('Invalid value for buckets')
     end
 
-    return global_metrics_registry:find_or_create(Histogram, name, help, buckets)
+    return registry:find_or_create(Histogram, name, help, buckets)
 end
 
 local function clear()
-    global_metrics_registry.collectors = {}
-    global_metrics_registry.callbacks = {}
-    global_metrics_registry.label_pairs = {}
+    registry.collectors = {}
+    registry.callbacks = {}
+    registry.label_pairs = {}
 end
 
 local function set_global_labels(label_pairs)
@@ -65,11 +65,11 @@ local function set_global_labels(label_pairs)
         end
     end
 
-    global_metrics_registry:set_labels(label_pairs)
+    registry:set_labels(label_pairs)
 end
 
 return {
-    global_registry = global_metrics_registry,
+    registry = registry,
 
     counter = counter,
     gauge = gauge,

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -29,31 +29,22 @@ end
 local function counter(name, help)
     checks('string', '?string')
 
-    return Counter.new(name, help)
+    return global_metrics_registry:find_or_create(Counter, name, help)
 end
 
 local function gauge(name, help)
     checks('string', '?string')
 
-    return Gauge.new(name, help)
-end
-
-function checkers.buckets(buckets)
-    local prev = -math.huge
-    for k, v in pairs(buckets) do
-        if type(k) ~= 'number' then return false end
-        if type(v) ~= 'number' then return false end
-        if v <= 0 then return false end
-        if prev > v then return false end
-        prev = v
-    end
-    return true
+    return global_metrics_registry:find_or_create(Gauge, name, help)
 end
 
 local function histogram(name, help, buckets)
-    checks('string', '?string', '?buckets')
+    checks('string', '?string', '?table')
+    if buckets ~= nil and not Histogram.check_buckets(buckets) then
+        error('Invalid value for buckets')
+    end
 
-    return Histogram.new(name, help, buckets)
+    return global_metrics_registry:find_or_create(Histogram, name, help, buckets)
 end
 
 local function clear()

--- a/metrics/registry.lua
+++ b/metrics/registry.lua
@@ -34,6 +34,7 @@ function Registry:register(collector)
     if self:find(collector.kind, collector.name) then
         error('Already registered')
     end
+    collector:set_registry(self)
     table.insert(self.collectors, collector)
     return collector
 end


### PR DESCRIPTION
- Collector is not added to registry when initialized. This makes it easier to create complex collectors from the several other ones. This inner collectors don't pollute statistics with intermediate values.
- Remove global variable `global_metrics_registry`. It's replaced with the default registry which is available via `metrics.registry`. When collector is added to the registry, registry is assigned to its `registry` field to give access to global tags (`label_pairs`).