### PR TITLE
Fix possible issue with wrong tagged metrics collection

### DIFF
--- a/metrics/collectors/shared.lua
+++ b/metrics/collectors/shared.lua
@@ -36,11 +36,12 @@ function Shared:set_registry(registry)
 end
 
 local function make_key(label_pairs)
-    local key = ''
+    local parts = {}
     for k, v in pairs(label_pairs) do
-        key = key .. k .. '\t' .. v .. '\t'
+        table.insert(parts, k .. '\t' .. v)
     end
-    return key
+    table.sort(parts)
+    return table.concat(parts, '\t')
 end
 
 function Shared:set(num, label_pairs)

--- a/test/collectors/shared_test.lua
+++ b/test/collectors/shared_test.lua
@@ -1,0 +1,18 @@
+local t = require('luatest')
+local g = t.group()
+
+local fun = require('fun')
+local Shared = require('metrics.collectors.shared')
+
+g.test_different_order_in_label_pairs = function()
+    local class = Shared:new_class('test_class', {'inc'})
+    local collector = class:new('test')
+    collector:inc(1, {a = 1, b = 2})
+    collector:inc(1, {a = 2, b = 1})
+    collector:inc(1, {b = 2, a = 1})
+    local observations = collector:collect()
+    t.assert_items_equals(fun.iter(observations):map(function(x) return {x.value, x.label_pairs} end):totable(), {
+        {2, {a = 1, b = 2}},
+        {1, {a = 2, b = 1}},
+    })
+end


### PR DESCRIPTION
Different storage key could be generated for the same tags.
In this case wrong metrics will be produced.