### PR TITLE
Add http middleware to collect response stats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ rpm:
 	tarantoolctl rocks install luatest 0.5.0
 	tarantoolctl rocks install luacov 0.13.0
 	tarantoolctl rocks install luacheck 0.25.0
+	tarantoolctl rocks install http 2.1.0
 
 .PHONY: lint
 lint: .rocks

--- a/metrics/collectors/average.lua
+++ b/metrics/collectors/average.lua
@@ -1,0 +1,59 @@
+local fiber = require('fiber')
+
+local Shared = require('metrics.collectors.shared')
+
+--- Collector to produce count and average value metrics.
+-- Average value is is calculated between two subsequent `:collect` calls.
+local Average = Shared:new_class('average')
+
+function Average:new(name, help)
+    local obj = Shared.new(self, name, help)
+    obj.count_name = name .. '_count'
+    obj.avg_name = name .. '_avg'
+    return obj
+end
+
+function Average:observe(value, label_pairs)
+    label_pairs = label_pairs or {}
+    local key = self.make_key(label_pairs)
+    local observation = self.observations[key]
+    if observation then
+        observation.count = observation.count + 1
+        observation.sum = observation.sum + value
+    else
+        self.observations[key] = {
+            label_pairs = label_pairs,
+            count = 1,
+            sum = value,
+            last_count = 0,
+            last_sum = 0,
+        }
+    end
+end
+
+function Average:collect()
+    local now = fiber.time64()
+    local result = {}
+    for _, observation in pairs(self.observations) do
+        local label_pairs = self:append_global_labels(observation.label_pairs)
+        table.insert(result, {
+            metric_name = self.count_name,
+            label_pairs = label_pairs,
+            value = observation.count,
+            timestamp = now,
+        })
+        local diff = observation.count - observation.last_count
+        local average = diff > 0 and ((observation.sum - observation.last_sum) / diff) or 0
+        table.insert(result, {
+            metric_name = self.avg_name,
+            label_pairs = label_pairs,
+            value = average,
+            timestamp = now,
+        })
+        observation.last_count = observation.count
+        observation.last_sum = observation.sum
+    end
+    return result
+end
+
+return Average

--- a/metrics/http_middleware.lua
+++ b/metrics/http_middleware.lua
@@ -1,0 +1,106 @@
+local clock = require('clock')
+local log = require('log')
+
+local export = {}
+
+export.DEFAULT_HISTOGRAM_BUCKETS = {
+    0.001,  0.0025, 0.005,  0.0075,
+    0.01,   0.025,  0.05,   0.075,
+    0.1,    0.25,   0.5,    0.75,
+    1.0,    2.5,    5.0,    7.5,
+    10.0,
+}
+
+--- Build default histogram collector
+--
+-- @string[opt='histogram'] type_name `histogram` or `average`
+-- @string[opt='http_server_requests'] name
+-- @string[opt='HTTP Server Requests'] help
+-- @return collector
+function export.build_default_collector(type_name, name, help)
+    type_name = type_name or 'histogram'
+    name = name or 'http_server_request_latency'
+    help = help or 'HTTP Server Request Latency'
+    local extra = {}
+    if type_name == 'histogram' then
+        extra = {export.DEFAULT_HISTOGRAM_BUCKETS}
+    elseif type_name ~= 'average' then
+        error('Unknown collector type_name: ' .. tostring(type_name))
+    end
+    local class = require('metrics.collectors.' .. type_name)
+    return require('metrics').registry:find_or_create(class, name, help, unpack(extra))
+end
+
+function export.get_default_collector()
+    if not export.default_collector then
+        export.default_collector = export.build_default_collector()
+    end
+    return export.default_collector
+end
+
+--- Set default collector for all middlewares
+--
+-- @tab collector object with `:collect` method.
+function export.set_default_collector(collector)
+    export.default_collector = collector
+end
+
+--- Build collector and set it as default
+--
+-- @see build_default_collector
+function export.configure_default_collector(...)
+    export.set_default_collector(export.build_default_collector(...))
+end
+
+--- Measure latency and invoke collector with labels from given route
+--
+-- @tab collector
+-- @tab route
+-- @string route.path
+-- @string route.method
+-- ... arguments for pcall to instrument
+function export.observe(collector, route, ...)
+    local start_time = clock.monotonic()
+    local ok, result = pcall(...)
+    local latency = clock.monotonic() - start_time
+
+    xpcall(function()
+        local status = (not ok and 500) or result.status or 200
+        collector:observe(latency, {path = route.path, method = route.method, status = status})
+    end, function(err)
+        log.error(debug.traceback('Saving metrics failed: ' .. tostring(err)))
+    end)
+
+    if not ok then
+        error(result)
+    end
+    return result
+end
+
+--- Apply instrumentation middleware for http request handler
+--
+-- @func handler original
+-- @func[opt] collector custom histogram-like collector
+-- @return new handler
+-- @usage httpd:route({method = 'GET', path = '/...'}, http_middleware.v1(request_handler))
+function export.v1(handler, collector)
+    collector = collector or export.get_default_collector()
+    return function(req)
+        return export.observe(collector, req.endpoint, handler, req)
+    end
+end
+
+--- Build middleware for http
+--
+-- @func[opt] collector custom histogram-like collector
+-- @return middleware
+-- @usage router:use(http_middleware.v2(), {name = 'http_instrumentation'})
+function export.v2(collector)
+    collector = collector or export.get_default_collector()
+    local tsgi = require('http.tsgi')
+    return function(env)
+        return export.observe(collector, env[tsgi.KEY_ROUTE].endpoint, tsgi.next, env)
+    end
+end
+
+return export

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -84,5 +84,6 @@ return {
     enable_default_metrics = function()
         return require('metrics.default_metrics.tarantool').enable()
     end,
+    http_middleware = require('metrics.http_middleware'),
     collect = collect,
 }

--- a/test/collectors/average_test.lua
+++ b/test/collectors/average_test.lua
@@ -1,0 +1,33 @@
+local t = require('luatest')
+local g = t.group()
+
+local utils = require('test.utils')
+
+local Average = require('metrics.collectors.average')
+
+g.test_collect = function()
+    local instance = Average:new('latency')
+    instance:observe(1)
+    instance:observe(2)
+    instance:observe(3, {tag = 'a'})
+    instance:observe(4, {tag = 'a'})
+    instance:observe(5, {tag = 'b'})
+
+    utils.assert_observations(instance:collect(), {
+        {'latency_count', 2, {}},
+        {'latency_avg', 1.5, {}},
+        {'latency_count', 2, {tag = 'a'}},
+        {'latency_avg', 3.5, {tag = 'a'}},
+        {'latency_count', 1, {tag = 'b'}},
+        {'latency_avg', 5, {tag = 'b'}},
+    })
+
+    utils.assert_observations(instance:collect(), {
+        {'latency_count', 2, {}},
+        {'latency_avg', 0, {}},
+        {'latency_count', 2, {tag = 'a'}},
+        {'latency_avg', 0, {tag = 'a'}},
+        {'latency_count', 1, {tag = 'b'}},
+        {'latency_avg', 0, {tag = 'b'}},
+    })
+end

--- a/test/http_middleware_test.lua
+++ b/test/http_middleware_test.lua
@@ -1,0 +1,155 @@
+local t = require('luatest')
+local g = t.group()
+
+local utils = require('test.utils')
+
+local fun = require('fun')
+local metrics = require('metrics')
+local http_middleware = metrics.http_middleware
+
+g.before_each(function()
+    metrics.clear()
+    http_middleware.set_default_collector(nil)
+end)
+
+g.after_all(function()
+    http_middleware.set_default_collector(nil)
+end)
+
+local function merge(...)
+    return fun.chain(...):tomap()
+end
+
+local route = {path = '/some/path', method = 'POST'}
+
+g.test_build_default_collector_histogram = function()
+    local collector = http_middleware.build_default_collector()
+    t.assert_equals(collector.kind, 'histogram')
+    t.assert_equals(collector.name, 'http_server_request_latency')
+    t.assert_equals(collector.help, 'HTTP Server Request Latency')
+    t.assert_equals(collector.buckets, http_middleware.DEFAULT_HISTOGRAM_BUCKETS)
+    collector = http_middleware.build_default_collector('histogram', 'custom_name', 'custom_help')
+    t.assert_equals(collector.kind, 'histogram')
+    t.assert_equals(collector.name, 'custom_name')
+    t.assert_equals(collector.help, 'custom_help')
+    t.assert_equals(collector.buckets, http_middleware.DEFAULT_HISTOGRAM_BUCKETS)
+end
+
+g.test_build_default_collector_average = function()
+    local collector = http_middleware.build_default_collector('average')
+    t.assert_equals(collector.kind, 'average')
+    t.assert_equals(collector.name, 'http_server_request_latency')
+    t.assert_equals(collector.help, 'HTTP Server Request Latency')
+    collector = http_middleware.build_default_collector('average', 'custom_name', 'custom_help')
+    t.assert_equals(collector.kind, 'average')
+    t.assert_equals(collector.name, 'custom_name')
+    t.assert_equals(collector.help, 'custom_help')
+end
+
+g.test_build_default_collector_invalid = function()
+    t.assert_error_msg_contains('Unknown collector type_name: some_type', function()
+        http_middleware.build_default_collector('some_type')
+    end)
+end
+
+g.test_observe = function()
+    local result = {value = 'result'}
+    local observed
+    local function subject()
+        return http_middleware.observe(
+            {observe = function(_, ...) observed = {...} return {'observer result'} end},
+            merge(route, {other = 'value'}),
+            function(arg1, arg2)
+                t.assert_equals({arg1, arg2}, {'value1', 'value2'})
+                return result
+            end,
+            'value1',
+            'value2'
+        )
+    end
+
+    t.assert_is(subject(), result)
+    t.assert_type(observed[1], 'number')
+    t.assert_equals(observed[2], merge(route, {status = 200}))
+
+    result.status = 400
+    t.assert_is(subject(), result)
+    t.assert_equals(observed[2], merge(route, {status = 400}))
+end
+
+g.test_observe_handler_failure = function()
+    local err = {custom = 'error'}
+    local observed
+    t.assert_equals(t.assert_error(function()
+        http_middleware.observe(
+            {observe = function(_, ...) observed = {...} return {'observer result'} end},
+            route,
+            function() error(err) end
+        )
+    end), err)
+    t.assert_type(observed[1], 'number')
+    t.assert_equals(observed[2], merge(route, {status = 500}))
+end
+
+g.test_observe_observer_failure = function()
+    local result = {value = 'result'}
+    local capture = require('luatest.capture'):new()
+    capture:wrap(true, function()
+        t.assert_is(http_middleware.observe(
+            {observe = function() error({custom = 'error'}) end},
+            route,
+            function() return result end
+        ), result)
+    end)
+    t.assert_str_contains(capture:flush().stderr, 'Saving metrics failed')
+end
+
+g.test_v1_middleware = function()
+    local request = {endpoint = table.copy(route)}
+    local result = {value = 'result'}
+    local observed
+    local observer = {observe = function(_, ...) observed = {...} end}
+    local handler = function(arg)
+        t.assert_is(arg, request)
+        return result
+    end
+
+    t.assert_is(http_middleware.v1(handler, observer)(request), result)
+    t.assert_equals(metrics.collect(), {})
+    t.assert_type(observed[1], 'number')
+    t.assert_equals(observed[2], merge(route, {status = 200}))
+
+    t.assert_is(http_middleware.v1(handler)(request), result)
+    t.assert_is(http_middleware.v1(handler)(request), result)
+    local observations = metrics.collect()
+    t.assert_equals(
+        utils.find_obs('http_server_request_latency_count', merge(route, {status = 200}), observations).value,
+        2
+    )
+    t.assert_type(
+        utils.find_obs('http_server_request_latency_sum', merge(route, {status = 200}), observations).value,
+        'number'
+    )
+end
+
+g.test_v2_middleware = function()
+    local httpd = require('http.server').new('127.0.0.1', 12345)
+    local router = require('http.router').new()
+    router:route(route, function() return {body = 'test-response', status = 200} end)
+    router:use(http_middleware.v2(), {name = 'http_instrumentation'})
+    httpd:set_router(router)
+    httpd:start()
+    local client = require('http.client').new()
+    local response = client:request(route.method, 'http://127.0.0.1:12345' .. route.path)
+    httpd:stop()
+    t.assert_equals(response.body, 'test-response')
+    local observations = metrics.collect()
+    t.assert_equals(
+        utils.find_obs('http_server_request_latency_count', merge(route, {status = 200}), observations).value,
+        1
+    )
+    t.assert_type(
+        utils.find_obs('http_server_request_latency_sum', merge(route, {status = 200}), observations).value,
+        'number'
+    )
+end

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -1,5 +1,8 @@
 local t = require('luatest')
 
+local fun = require('fun')
+local metrics = require('metrics')
+
 local utils = {}
 
 function utils.find_obs(metric_name, label_pairs, observations)
@@ -10,6 +13,28 @@ function utils.find_obs(metric_name, label_pairs, observations)
         end
     end
     t.fail("haven't found observation")
+end
+
+function utils.observations_without_timestamps(observations)
+    return fun.iter(observations or metrics.collect()):
+        map(function(x)
+            x.timestamp = nil
+            return x
+        end):
+        totable()
+end
+
+function utils.assert_observations(actual, expected)
+    t.assert_items_equals(
+        utils.observations_without_timestamps(actual),
+        fun.iter(expected):map(function(x)
+            return {
+                metric_name = x[1],
+                value = x[2],
+                label_pairs = x[3],
+            }
+        end):totable()
+    )
 end
 
 return utils

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -12,7 +12,8 @@ function utils.find_obs(metric_name, label_pairs, observations)
             return obs
         end
     end
-    t.fail("haven't found observation")
+    t.assert_items_include(observations, {metric_name = metric_name, label_pairs = label_pairs},
+        'Missing observation')
 end
 
 function utils.observations_without_timestamps(observations)


### PR DESCRIPTION
It can be used with average collector from #58 like this:

```lua
-- v1
metrics.http_middleware.set_default_collector(metrics.average('http_server_request_latency'))
-- v2
router:use(metrics.http_middleware.v2(metrics.average('http_server_request_latency')), {...})
```

I'm not sure if we need additional options for this.