### PR TITLE
fix: vclock index in replicas metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Throw exception when `http_middleware.build_default_collector` is called with same name
+- Attempt to index non-existent master vclock on a replica after the death of the master
 
 ## [0.2.0] - 2020-05-07
 ### Added

--- a/metrics/default_metrics/tarantool/replicas.lua
+++ b/metrics/default_metrics/tarantool/replicas.lua
@@ -10,8 +10,11 @@ local function update_replicas_metrics()
 
     if box.cfg.read_only then
         for k, v in ipairs(current_box_info.vclock) do
-            local lsn = current_box_info.replication[k].lsn
-            utils.set_gauge('replication_replica_' .. k .. '_lsn', 'lsn for replica ' .. k, lsn - v)
+            local replication_info = current_box_info.replication[k]
+            if replication_info then
+                local lsn = replication_info.lsn
+                utils.set_gauge('replication_replica_' .. k .. '_lsn', 'lsn for replica ' .. k, lsn - v)
+            end
         end
     else
         for k, v in ipairs(current_box_info.replication) do


### PR DESCRIPTION

```
xpcall(package.loaded.metrics.invoke_callbacks, function(x) return {x, debug.traceback()} end)
---
- false
- - '...tarantool/metrics/default_metrics/tarantool/replicas.lua:13: attempt to index
    a nil value'
  - "stack traceback:\n\t[string \"return xpcall(package.loaded.metrics.invoke_c...\"]:1:
    in function '__index'\n\t...tarantool/metrics/default_metrics/tarantool/replicas.lua:13:
    in function 'registered_callback'\n\t/home/tarantool/.rocks/share/tarantool/metrics/registry.lua:55:
    in function </home/tarantool/.rocks/share/tarantool/metrics/registry.lua:53>\n\t[builtin#21]:
    at 0x00577bf0\n\t[C]: in function 'pcall'\n\tbuiltin/box/console.lua:153: in function
    'eval'\n\tbuiltin/box/console.lua:409: in function 'repl'\n\tbuiltin/box/console.lua:543:
    in function <builtin/box/console.lua:529>\n\t[C]: in function 'pcall'\n\tbuiltin/socket.lua:1068:
    in function <builtin/socket.lua:1066>"
...
