### PR TITLE
graphite: values now without ULL suffix, timestamps in seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cartridge role is permanent
 - cartridge role configuration without clusterwide config
 - graphite plugin kills previous workers on init
+- graphite plugin format numbers without ULL/LL-suffixes
+- graphite plugin time in seconds
 
 ### Added
 - Luajit platform metrics

--- a/metrics/plugins/graphite/init.lua
+++ b/metrics/plugins/graphite/init.lua
@@ -16,7 +16,7 @@ local DEFAULT_SEND_INTERVAL = 2
 -- Constants
 local LABELS_SEP = ';'
 
-local function format_observation(prefix, obs)
+function graphite.format_observation(prefix, obs)
     local metric_path = #prefix > 0 and ('%s.%s'):format(prefix, obs.metric_name) or obs.metric_name
 
     if next(obs.label_pairs) then
@@ -28,9 +28,10 @@ local function format_observation(prefix, obs)
         metric_path = metric_path .. LABELS_SEP .. label_pairs_str
     end
     metric_path = metric_path:gsub(' ', '_') -- remove spaces (e.g. in values)
+    local string_val = tostring(obs.value):match('%d*') -- removes ULL/LL suffixes
 
-    local ts = tostring(obs.timestamp):sub(1, -4) -- remove ULL suffix
-    local graph = ('%s %s %s\n'):format(metric_path, obs.value, ts)
+    local ts = tostring(obs.timestamp):sub(1, -10) -- Graphite takes time in seconds
+    local graph = ('%s %s %s\n'):format(metric_path, string_val, ts)
 
     return graph
 end

--- a/test/plugins/graphite_test.lua
+++ b/test/plugins/graphite_test.lua
@@ -37,6 +37,47 @@ g.after_each(function()
     metrics.clear()
 end)
 
+g.test_graphite_format_observation_removes_ULL_suffix = function()
+    local gauge = metrics.gauge('test_gauge', 'Test gauge')
+    gauge:set(1ULL)
+    local obs = gauge:collect()[1]
+    local ull_number = tostring(obs.value)
+    t.assert_equals(ull_number, '1ULL')
+
+    local graphite_obs = graphite.format_observation('', obs)
+
+    local graphite_val = graphite_obs:split(' ')[2]
+    t.assert_equals(graphite_val, '1')
+end
+
+g.test_graphite_format_observation_removes_LL_suffix = function()
+    local gauge = metrics.gauge('test_gauge', 'Test gauge')
+    gauge:set(1LL)
+    local obs = gauge:collect()[1]
+    local ll_number = tostring(obs.value)
+    t.assert_equals(ll_number, '1LL')
+
+    local graphite_obs = graphite.format_observation('', obs)
+
+    local graphite_val = graphite_obs:split(' ')[2]
+    t.assert_equals(graphite_val, '1')
+end
+
+g.test_graphite_format_observation_time_in_seconds = function()
+    local obs = {
+        metric_name = 'test_metric',
+        label_pairs = {},
+        value = 1,
+        timestamp = fiber.time64(),
+    }
+
+    local graphite_obs = graphite.format_observation('', obs)
+
+    local graphite_time = tonumber(graphite_obs:split(' ')[3])
+    local sec = obs.timestamp / 10^6
+    t.assert_equals(graphite_time, sec)
+end
+
 local function mock_graphite_worker()
     fiber.create(function()
         fiber.name('metrics_graphite_worker')
@@ -62,4 +103,3 @@ g.test_graphite_kills_previous_fibers_on_init = function()
     workers_cnt = count_workers()
     t.assert_equals(workers_cnt, 1)
 end
-


### PR DESCRIPTION
Closes #90 #86 