### PR TITLE
add luajit platform metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - metrics.clear() disables default metrics
 
+### Added
+- Luajit platform metrics
+
 ## [0.5.0] - 2020-09-18
 ### Added
 - Summary collector

--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -48,6 +48,7 @@ build = {
         ['metrics.default_metrics.tarantool.system']     = 'metrics/default_metrics/tarantool/system.lua',
         ['metrics.psutils.cpu']                          = 'metrics/psutils/cpu.lua',
         ['metrics.psutils.psutils_linux']                = 'metrics/psutils/psutils_linux.lua',
+        ['metrics.tarantool.luajit']                     = 'metrics/tarantool/luajit.lua',
         ['metrics.utils']                                = 'metrics/utils.lua',
         ['cartridge.roles.metrics']                      = 'cartridge/roles/metrics.lua',
     }

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -93,7 +93,8 @@ return {
     invoke_callbacks = invoke_callbacks,
     set_global_labels = set_global_labels,
     enable_default_metrics = function()
-        return require('metrics.default_metrics.tarantool').enable()
+        require('metrics.tarantool.luajit').enable()
+        require('metrics.default_metrics.tarantool').enable()
     end,
     http_middleware = require('metrics.http_middleware'),
     collect = collect,

--- a/metrics/tarantool/luajit.lua
+++ b/metrics/tarantool/luajit.lua
@@ -1,5 +1,7 @@
 local metrics = require('metrics')
 
+local Shared = require('metrics.collectors.shared')
+
 local has_mics_module, misc = pcall(require, 'misc')
 
 local LJ_PREFIX = 'lj_'
@@ -13,18 +15,26 @@ local function set_gauge(name, description, value, labels)
     gauge:set(value, labels or {})
 end
 
+local function set_counter(name, description, value, labels)
+    local counter = metrics.counter(prefix_name(name), description)
+    if counter.set == nil then
+        counter.set = Shared.set
+    end
+    counter:set(value, labels or {})
+end
+
 local function update()
     -- Details: https://github.com/tarantool/doc/issues/1597
     local lj_metrics = misc.getmetrics()
-    set_gauge('gc_freed', 'Total amount of freed memory',
+    set_counter('gc_freed', 'Total amount of freed memory',
         lj_metrics.gc_freed)
-    set_gauge('strhash_hit', 'Number of strings being interned',
+    set_counter('strhash_hit', 'Number of strings being interned',
         lj_metrics.strhash_hit)
-    set_gauge('gc_steps_atomic', 'Count of incremental GC steps (atomic state)',
+    set_counter('gc_steps_atomic', 'Count of incremental GC steps (atomic state)',
         lj_metrics.gc_steps_atomic)
-    set_gauge('strhash_miss', 'Total number of strings allocations during the platform lifetime',
+    set_counter('strhash_miss', 'Total number of strings allocations during the platform lifetime',
         lj_metrics.strhash_miss)
-    set_gauge('gc_steps_sweepstring', 'Count of incremental GC steps (sweepstring state)',
+    set_counter('gc_steps_sweepstring', 'Count of incremental GC steps (sweepstring state)',
         lj_metrics.gc_steps_sweepstring)
     set_gauge('gc_strnum', 'Amount of allocated string objects',
         lj_metrics.gc_strnum)
@@ -32,27 +42,27 @@ local function update()
         lj_metrics.gc_tabnum)
     set_gauge('gc_cdatanum', 'Amount of allocated cdata objects',
         lj_metrics.gc_cdatanum)
-    set_gauge('jit_snap_restore', 'Overall number of snap restores',
+    set_counter('jit_snap_restore', 'Overall number of snap restores',
         lj_metrics.jit_snap_restore)
     set_gauge('gc_total', 'Memory currently allocated',
         lj_metrics.gc_total)
     set_gauge('gc_udatanum', 'Amount of allocated udata objects',
         lj_metrics.gc_udatanum)
-    set_gauge('gc_steps_finalize', 'Count of incremental GC steps (finalize state)',
+    set_counter('gc_steps_finalize', 'Count of incremental GC steps (finalize state)',
         lj_metrics.gc_steps_finalize)
-    set_gauge('gc_allocated', 'Total amount of allocated memory',
+    set_counter('gc_allocated', 'Total amount of allocated memory',
         lj_metrics.gc_allocated)
     set_gauge('jit_trace_num', 'Amount of JIT traces',
         lj_metrics.jit_trace_num)
-    set_gauge('gc_steps_sweep', 'Count of incremental GC steps (sweep state)',
+    set_counter('gc_steps_sweep', 'Count of incremental GC steps (sweep state)',
         lj_metrics.gc_steps_sweep)
-    set_gauge('jit_trace_abort', 'Overall number of abort traces',
+    set_counter('jit_trace_abort', 'Overall number of abort traces',
         lj_metrics.jit_trace_abort)
     set_gauge('jit_mcode_size', 'Total size of all allocated machine code areas',
         lj_metrics.jit_mcode_size)
-    set_gauge('gc_steps_propagate', 'Count of incremental GC steps (propagate state)',
+    set_counter('gc_steps_propagate', 'Count of incremental GC steps (propagate state)',
         lj_metrics.gc_steps_propagate)
-    set_gauge('gc_steps_pause', 'Count of incremental GC steps (pause state)',
+    set_counter('gc_steps_pause', 'Count of incremental GC steps (pause state)',
         lj_metrics.gc_steps_pause)
 end
 

--- a/metrics/tarantool/luajit.lua
+++ b/metrics/tarantool/luajit.lua
@@ -1,0 +1,69 @@
+local metrics = require('metrics')
+
+local has_mics_module, misc = pcall(require, 'misc')
+
+local LJ_PREFIX = 'lj_'
+
+local function prefix_name(name)
+    return LJ_PREFIX .. name
+end
+
+local function set_gauge(name, description, value, labels)
+    local gauge = metrics.gauge(prefix_name(name), description)
+    gauge:set(value, labels or {})
+end
+
+local function update()
+    -- Details: https://github.com/tarantool/doc/issues/1597
+    local lj_metrics = misc.getmetrics()
+    set_gauge('gc_freed', 'Total amount of freed memory',
+        lj_metrics.gc_freed)
+    set_gauge('strhash_hit', 'Number of strings being interned',
+        lj_metrics.strhash_hit)
+    set_gauge('gc_steps_atomic', 'Count of incremental GC steps (atomic state)',
+        lj_metrics.gc_steps_atomic)
+    set_gauge('strhash_miss', 'Total number of strings allocations during the platform lifetime',
+        lj_metrics.strhash_miss)
+    set_gauge('gc_steps_sweepstring', 'Count of incremental GC steps (sweepstring state)',
+        lj_metrics.gc_steps_sweepstring)
+    set_gauge('gc_strnum', 'Amount of allocated string objects',
+        lj_metrics.gc_strnum)
+    set_gauge('gc_tabnum', 'Amount of allocated table objects',
+        lj_metrics.gc_tabnum)
+    set_gauge('gc_cdatanum', 'Amount of allocated cdata objects',
+        lj_metrics.gc_cdatanum)
+    set_gauge('jit_snap_restore', 'Overall number of snap restores',
+        lj_metrics.jit_snap_restore)
+    set_gauge('gc_total', 'Memory currently allocated',
+        lj_metrics.gc_total)
+    set_gauge('gc_udatanum', 'Amount of allocated udata objects',
+        lj_metrics.gc_udatanum)
+    set_gauge('gc_steps_finalize', 'Count of incremental GC steps (finalize state)',
+        lj_metrics.gc_steps_finalize)
+    set_gauge('gc_allocated', 'Total amount of allocated memory',
+        lj_metrics.gc_allocated)
+    set_gauge('jit_trace_num', 'Amount of JIT traces',
+        lj_metrics.jit_trace_num)
+    set_gauge('gc_steps_sweep', 'Count of incremental GC steps (sweep state)',
+        lj_metrics.gc_steps_sweep)
+    set_gauge('jit_trace_abort', 'Overall number of abort traces',
+        lj_metrics.jit_trace_abort)
+    set_gauge('jit_mcode_size', 'Total size of all allocated machine code areas',
+        lj_metrics.jit_mcode_size)
+    set_gauge('gc_steps_propagate', 'Count of incremental GC steps (propagate state)',
+        lj_metrics.gc_steps_propagate)
+    set_gauge('gc_steps_pause', 'Count of incremental GC steps (pause state)',
+        lj_metrics.gc_steps_pause)
+end
+
+local enable = function() end
+
+if has_mics_module and misc.getmetrics ~= nil then
+    enable = function()
+        metrics.register_callback(update)
+    end
+end
+
+return {
+    enable = enable,
+}

--- a/rpm/tarantool-metrics.spec
+++ b/rpm/tarantool-metrics.spec
@@ -61,6 +61,8 @@ cp -rv cartridge %{br_luapkgdir}
      %{luapkgdir}/metrics/psutils/cpu.lua
      %{luapkgdir}/metrics/psutils/psutils_linux.lua
      %{luapkgdir}/metrics/utils.lua
+%dir %{luapkgdir}/metrics/tarantool
+     %{luapkgdir}/metrics/tarantool/luajit.lua
 %dir %{luapkgdir}/cartridge
 %dir %{luapkgdir}/cartridge/roles
      %{luapkgdir}/cartridge/roles/metrics.lua

--- a/test/lj_metrics_test.lua
+++ b/test/lj_metrics_test.lua
@@ -1,0 +1,54 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+
+local t = require('luatest')
+local g = t.group('luajit_metrics')
+
+local metrics = require('metrics')
+
+local LJ_PREFIX = 'lj_'
+
+g.after_each(function()
+    -- Delete all collectors and global labels
+    metrics.clear()
+end)
+
+g.test_lj_metrics = function()
+    local metrics_available = pcall(require, 'misc')
+    t.skip_if(metrics_available == false, 'metrics are not available')
+
+    metrics.enable_default_metrics()
+    metrics.invoke_callbacks()
+
+    local lj_metrics = {}
+    for _, v in pairs(metrics.collect()) do
+        if v.metric_name:startswith(LJ_PREFIX) then
+            table.insert(lj_metrics, v.metric_name)
+        end
+    end
+
+    local expected_lj_metrics = {
+        "lj_gc_freed",
+        "lj_strhash_hit",
+        "lj_gc_steps_atomic",
+        "lj_strhash_miss",
+        "lj_gc_steps_sweepstring",
+        "lj_gc_strnum",
+        "lj_gc_tabnum",
+        "lj_gc_cdatanum",
+        "lj_jit_snap_restore",
+        "lj_gc_total",
+        "lj_gc_udatanum",
+        "lj_gc_steps_finalize",
+        "lj_gc_allocated",
+        "lj_jit_trace_num",
+        "lj_gc_steps_sweep",
+        "lj_jit_trace_abort",
+        "lj_jit_mcode_size",
+        "lj_gc_steps_propagate",
+        "lj_gc_steps_pause",
+    }
+
+    t.assert_covers(lj_metrics, expected_lj_metrics)
+end


### PR DESCRIPTION
After https://github.com/tarantool/tarantool/issues/5187 tarantool
could report luajit platform metrics.

This patch exports them as default metrics.
For detailed description of each metric see
https://github.com/tarantool/doc/issues/1597.

Closes #127