### PR TITLE
fix default metrics collection after metrics.clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- metrics.clear() disables default metrics
 
 ## [0.5.0] - 2020-09-18
 ### Added

--- a/metrics/utils.lua
+++ b/metrics/utils.lua
@@ -1,7 +1,5 @@
 local metrics = require('metrics')
 
-local gauges_storage = {}
-
 local TNT_PREFIX = 'tnt_'
 
 local function prefix_name(name)
@@ -9,13 +7,9 @@ local function prefix_name(name)
 end
 
 local function set_gauge(name, description, value, labels)
-    if (gauges_storage[name] == nil) then
-        gauges_storage[name] = metrics.gauge(prefix_name(name), description)
-    end
-
-    gauges_storage[name]:set(value, labels or {})
+    local gauge = metrics.gauge(prefix_name(name), description)
+    gauge:set(value, labels or {})
 end
-
 
 local function box_is_configured()
     return type(box.cfg) ~= 'function'

--- a/test/default_metrics_test.lua
+++ b/test/default_metrics_test.lua
@@ -1,0 +1,34 @@
+#!/usr/bin/env tarantool
+
+require('strict').on()
+
+local t = require('luatest')
+local g = t.group('default_metrics')
+
+local metrics = require('metrics')
+
+g.before_all(function()
+    box.cfg{}
+    metrics.clear()
+end)
+
+g.after_each(function()
+    -- Delete all collectors and global labels
+    metrics.clear()
+end)
+
+g.test_default_metrics_clear = function()
+    metrics.clear()
+    metrics.enable_default_metrics()
+    t.assert_equals(#metrics.collect(), 0)
+
+    metrics.invoke_callbacks()
+    t.assert(#metrics.collect() > 0)
+
+    metrics.clear()
+    t.assert_equals(#metrics.collect(), 0)
+
+    metrics.enable_default_metrics()
+    metrics.invoke_callbacks()
+    t.assert(#metrics.collect() > 0)
+end


### PR DESCRIPTION
This metrics was cleared from global registry but was still saved
in local registry (in utils.lua).
But actually after f73c0eeda053e94be74edb2a1ac39b54bebe0363 this
cache is redundant. This patch removes it and introduces a test
to check enable_default_metrics works correctly after clear.

Closes #130