### PR TITLE
Promtool test: new go version in CI and luatest fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.13'
+          go-version: '1.15'
 
       - name: promtool test
         run: |

--- a/test/promtool_test.lua
+++ b/test/promtool_test.lua
@@ -17,5 +17,3 @@ gauge:set(1)
 local fh = fio.open('prometheus-input', {'O_RDWR', 'O_CREAT'}, tonumber('644',8))
 fh:write(prometheus.collect_http().body)
 fh:close()
-
-os.exit()


### PR DESCRIPTION
promtool test fails because of go version. 
luatest exited before end of testing - fixed
Close #166 and #168