### PR TITLE
instance_name in alias label if no alias present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - package reloading works for `metrics.quantile`
+- instance_name in alias label if no alias present
 
 ## [0.6.0] - 2020-12-01
 ### Fixed

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -18,7 +18,7 @@ local handlers = {
 local function init()
     local params, err = argparse.parse()
     assert(params, err)
-    metrics.set_global_labels({alias = params.alias})
+    metrics.set_global_labels({alias = params.alias or params.instance_name})
     metrics.enable_default_metrics()
     metrics.enable_cartridge_metrics()
 end

--- a/test/unit/cartridge_role_test.lua
+++ b/test/unit/cartridge_role_test.lua
@@ -1,0 +1,46 @@
+local metrics
+
+local helpers = require('test.helper')
+
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
+end
+
+g.after_each = function()
+    metrics.clear()
+end
+
+g.after_all = function()
+    package.loaded['cartridge.argparse'] = nil
+end
+
+local function mock_argparse(params)
+    package.loaded['cartridge.argparse'] = {
+        parse = function()
+            return params
+        end
+    }
+    package.loaded['cartridge.roles.metrics'] = nil
+    metrics = require('cartridge.roles.metrics')
+end
+
+local label_tests = {
+    test_init_alias_lebel_present_with_alias_var = {alias = 'alias'},
+    test_init_alias_lebel_present_with_instance_var = {instance_name = 'alias'},
+    test_init_alias_lebel_is_present_no_alias_var = {},
+}
+
+for test_name, params in pairs(label_tests) do
+    g[test_name] = function()
+        mock_argparse(params)
+
+        metrics.init()
+
+        metrics.counter('test-counter'):inc(1)
+        local alias_label = metrics.collect()[1].label_pairs.alias
+        t.assert_equals(alias_label, params.alias or params.instance_name)
+    end
+end


### PR DESCRIPTION
Instance_name in alias label if no alias present.

No integration tests because `'alias'` field in `cartridge.test-helpers` is required.
I didn't forget about

- [x] Tests
- [x] Changelog

Close #162 
