### PR TITLE
Add Grafana dashboard documentation on tarantool.io

### DIFF
--- a/doc/monitoring/getting_started.rst
+++ b/doc/monitoring/getting_started.rst
@@ -192,5 +192,3 @@ via configuration.
              format: 'json'
            - path: '/another_path_for_json_metrics'
              format: 'json'
-
-.. _grafana-dashboard:

--- a/doc/monitoring/index.rst
+++ b/doc/monitoring/index.rst
@@ -18,3 +18,4 @@ This chapter includes the following sections:
    metrics_reference
    api_reference
    plugins
+   grafana_dashboard


### PR DESCRIPTION
Closes https://github.com/tarantool/grafana-dashboard/issues/45 together with https://github.com/tarantool/doc/pull/1802 and https://github.com/tarantool/grafana-dashboard/pull/50

Dependencies structure: `grafana-dashboard` includes folder 'monitoring' with documentation text and images that should merged with `metrics` folder 'monitoring' on doc build; `metrics` adds documentation to index page; `doc` adds grafana-dashoard as a submodule and fetches its content.