### PR TITLE
Add zone label for Tarantool Cartridge 2.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           - "2.5"
           - "2.6"
           - "2.7.0"
-        cartridge: [ "", "1.2.0", "2.1.2" ]
+        cartridge: [ "", "1.2.0", "2.1.2", "2.4.0", "2.5.0" ]
     runs-on: ubuntu-latest
     container:
       image: tarantool/tarantool:${{ matrix.tarantool }}
@@ -52,9 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install Taranool
+      - name: install Tarantool
         run: |
-          curl -L https://tarantool.io/aYJZbH/release/2.3/installer.sh | bash
+          curl -L https://tarantool.io/installer.sh | sudo VER=2.4 bash
+          sudo apt install -y tarantool-dev
 
       - uses: actions/setup-go@v2
         with:
@@ -62,5 +63,5 @@ jobs:
 
       - name: promtool test
         run: |
-          go get github.com/prometheus/prometheus/cmd/promtool
+          GO111MODULE=on go get github.com/prometheus/prometheus/cmd/promtool@a6be548dbc17780d562a39c0e4bd0bd4c00ad6e2
           make test_promtool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- zone label support for Tarantool Cartridge >= '2.4.0'
 
 ## [0.7.0] - 2021-02-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ via configuration.
    local metrics = cartridge.service_get('metrics')
    ```
 
+5. There is an ability in Tarantool Cartridge >= '2.4.0' to set a zone for each 
+   server in cluster. If zone was set for the server 'zone' label for all metrics 
+   of this server will be added.
+   
 ## Next steps
 
 See:

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -19,10 +19,19 @@ local handlers = {
     end,
 }
 
-local function init()
+local function set_labels()
     local params, err = argparse.parse()
     assert(params, err)
-    metrics.set_global_labels({alias = params.alias or params.instance_name})
+    local this_instance = cartridge.admin_get_servers(box.info.uuid)
+    local zone
+    if this_instance and this_instance[1] then
+        zone = this_instance[1].zone
+    end
+    metrics.set_global_labels({alias = params.alias or params.instance_name, zone = zone})
+end
+
+local function init()
+    set_labels()
     metrics.enable_default_metrics()
     metrics.enable_cartridge_metrics()
 end
@@ -118,6 +127,7 @@ local function apply_config(conf)
         end
         metrics_config_present = false
     end
+    set_labels()
     apply_routes(metrics_conf.export)
 end
 

--- a/doc/monitoring/getting_started.rst
+++ b/doc/monitoring/getting_started.rst
@@ -178,6 +178,10 @@ via configuration.
        local cartridge = require('cartridge')
        local metrics = cartridge.service_get('metrics')
 
+#. There is an ability in Tarantool Cartridge >= ``'2.4.0'`` to set a zone for each 
+   server in cluster. If zone was set for the server ``'zone'`` label for all metrics 
+   of this server will be added.
+
 #. To change metrics HTTP path in **runtime**, you may use the following configuration
    (to learn more about Cartridge configuration, see
    `this <https://www.tarantool.io/en/doc/latest/book/cartridge/topics/clusterwide-config/#managing-role-specific-data>`_).


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

Added zone label for instance metrics to support zones introduced in Tarantool Cartridge 2.4.0

I didn't forget about

- [X] Tests
- [X] Changelog
- [X] Documentation (README and rst)
- [X] Rockspec and rpm spec

Close https://github.com/tarantool/metrics/issues/194

Note: promtool has an issue: https://github.com/prometheus/prometheus/issues/8480 but it doesn't helps.
