### PR TITLE
`disable_global_issues` function that disables metric `tnt_cartridge_issues`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - New default metrics: cpu_user_time, cpu_system_time
+- `disable_global_issues` function that disables metric `tnt_cartridge_issues`
+
+### Deprecated
+- enabling `tnt_cartridge_issues` metric by default
 
 ## [0.7.1] - 2021-03-18
 ### Added

--- a/doc/monitoring/metrics_reference.rst
+++ b/doc/monitoring/metrics_reference.rst
@@ -221,15 +221,20 @@ Runtime
 Cartridge
 -------------------------------------------------------------------------------
 
-``cartridge_issues``—Number of
-:ref:`issues across cluster instances <cartridge.issues>`.
-This metric always has label ``{level="critical"}``, where
-``level`` is the level of the issue:
+* ``tnt_cartridge_issues``—Number of
+  :ref:`issues across cluster instances <cartridge.issues>`.
+  This metric always has label ``{level="critical"}``, where
+  ``level`` is the level of the issue:
 
-*   ``critical`` level is associated with critical
-    cluster problems, for example when memory used ratio is more than 90%.
-*   ``warning`` level is associated with
-    other cluster problems, e.g. replication issues on cluster.
+  *   ``critical`` level is associated with critical
+      cluster problems, for example when memory used ratio is more than 90%.
+  *   ``warning`` level is associated with
+      other cluster problems, e.g. replication issues on cluster.
+
+  This metric **will be disabled by default** in next releases.
+  To disable it use ``require('metrics.cartridge.issues').disable_global_issues()``.
+  It's not recommended to enable cluster issues on each instance because it
+  makes N network requests per instance (N is the number of instances in cluster).
 
 .. _metrics-luajit:
 

--- a/metrics/cartridge/issues.lua
+++ b/metrics/cartridge/issues.lua
@@ -1,10 +1,12 @@
 local utils = require('metrics.utils');
 local fun = require('fun')
 
+local gather_global_issues = true
+
 local function update_info_metrics()
     local status, cartridge_issues = pcall(require, 'cartridge.issues')
 
-    if status ~= true then
+    if not gather_global_issues and status ~= true then
         return
     end
 
@@ -14,11 +16,16 @@ local function update_info_metrics()
 
     for _, level in ipairs(levels) do
         local len = fun.iter(issues):filter(function(x) return x.level == level end):length()
-        utils.set_gauge('cartridge_issues', 'Tarantool Cartridge issues', len, {level = level})
+        utils.set_gauge(cartridge_issues, 'Tarantool Cartridge issues', len, {level = level})
     end
 
 end
 
+local function disable_global_issues()
+    gather_global_issues = false
+end
+
 return {
     update = update_info_metrics,
+    disable_global_issues = disable_global_issues,
 }


### PR DESCRIPTION
Added `disable_global_issues` function that disables metric `tnt_cartridge_issues`
It should be called only on instances that should gather issues (e.g. on routers)

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rst)

Close #211 
Also close #212
