### PR TITLE
cpu metrics: introduce metrics to gather cpu usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New default metrics: cpu_user_time, cpu_system_time
 
 ## [0.7.1] - 2021-03-18
 ### Added

--- a/doc/monitoring/metrics_reference.rst
+++ b/doc/monitoring/metrics_reference.rst
@@ -306,3 +306,8 @@ They are only available on Linux.
     *   ``kind`` can be either ``user`` or ``system``.
     *   ``thread_name`` is ``tarantool``, ``wal``, ``iproto``, or ``coio``.
     *   ``file_name`` is the entrypoint file name, for example, ``init.lua``.
+
+There are also the following cross-platform metrics obtained using the call ``getrusage()``
+
+* ``tnt_cpu_user_time`` - Tarantool CPU user time.
+* ``tnt_cpu_system_time`` - Tarantool CPU system time.

--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -46,6 +46,7 @@ build = {
         ['metrics.default_metrics.tarantool.slab']       = 'metrics/default_metrics/tarantool/slab.lua',
         ['metrics.default_metrics.tarantool.spaces']     = 'metrics/default_metrics/tarantool/spaces.lua',
         ['metrics.default_metrics.tarantool.system']     = 'metrics/default_metrics/tarantool/system.lua',
+        ['metrics.default_metrics.tarantool.cpu']        = 'metrics/default_metrics/tarantool/cpu.lua',
         ['metrics.cartridge']                            = 'metrics/cartridge.lua',
         ['metrics.cartridge.issues']                     = 'metrics/cartridge/issues.lua',
         ['metrics.psutils.cpu']                          = 'metrics/psutils/cpu.lua',

--- a/metrics/default_metrics/tarantool/cpu.lua
+++ b/metrics/default_metrics/tarantool/cpu.lua
@@ -1,0 +1,74 @@
+local ffi = require('ffi')
+local utils = require('metrics.utils')
+
+if ffi.os == 'OSX' then
+  ffi.cdef[[
+    typedef int32_t suseconds_t;
+    struct timeval {
+      long        tv_sec;     /* seconds */
+      suseconds_t tv_usec;    /* microseconds */
+    };
+  ]]
+else
+  ffi.cdef[[
+    struct timeval {
+      long tv_sec;     /* seconds */
+      long tv_usec;    /* microseconds */
+    };
+  ]]
+end
+
+ffi.cdef[[
+  struct rusage {
+    struct timeval ru_utime; /* user CPU time used */
+    struct timeval ru_stime; /* system CPU time used */
+    long   ru_maxrss;        /* maximum resident set size */
+    long   ru_ixrss;         /* integral shared memory size */
+    long   ru_idrss;         /* integral unshared data size */
+    long   ru_isrss;         /* integral unshared stack size */
+    long   ru_minflt;        /* page reclaims (soft page faults) */
+    long   ru_majflt;        /* page faults (hard page faults) */
+    long   ru_nswap;         /* swaps */
+    long   ru_inblock;       /* block input operations */
+    long   ru_oublock;       /* block output operations */
+    long   ru_msgsnd;        /* IPC messages sent */
+    long   ru_msgrcv;        /* IPC messages received */
+    long   ru_nsignals;      /* signals received */
+    long   ru_nvcsw;         /* voluntary context switches */
+    long   ru_nivcsw;        /* involuntary context switches */
+  };
+  int getrusage(int who, struct rusage *usage);
+  int gettimeofday(struct timeval *tv, struct timezone *tz);
+]]
+
+local RUSAGE_SELF = 0
+
+local shared_rusage = ffi.new("struct rusage[1]")
+
+local function ss_get_rusage()
+    if ffi.C.getrusage(RUSAGE_SELF, shared_rusage) < 0 then
+        return nil
+    end
+
+    local ru_utime = tonumber(shared_rusage[0].ru_utime.tv_sec) +
+                     (tonumber(shared_rusage[0].ru_utime.tv_usec) / 1000000)
+    local ru_stime = tonumber(shared_rusage[0].ru_stime.tv_sec) +
+                     (tonumber(shared_rusage[0].ru_stime.tv_usec) / 1000000)
+
+    return {
+      ru_utime = ru_utime,
+      ru_stime = ru_stime,
+    }
+end
+
+local function update_info_metrics()
+    local cpu_time = ss_get_rusage()
+    if cpu_time then
+        utils.set_gauge('cpu_user_time', 'CPU user time usage', cpu_time.ru_utime)
+        utils.set_gauge('cpu_system_time', 'CPU system time usage', cpu_time.ru_stime)
+    end
+end
+
+return {
+    update = update_info_metrics
+}

--- a/metrics/default_metrics/tarantool/init.lua
+++ b/metrics/default_metrics/tarantool/init.lua
@@ -11,6 +11,7 @@ local default_metrics = {
     require('metrics.default_metrics.tarantool.memory'),
     require('metrics.default_metrics.tarantool.spaces'),
     require('metrics.default_metrics.tarantool.fibers'),
+    require('metrics.default_metrics.tarantool.cpu'),
 }
 
 local function enable()

--- a/rpm/tarantool-metrics.spec
+++ b/rpm/tarantool-metrics.spec
@@ -57,6 +57,7 @@ cp -rv cartridge %{br_luapkgdir}
      %{luapkgdir}/metrics/default_metrics/tarantool/slab.lua
      %{luapkgdir}/metrics/default_metrics/tarantool/spaces.lua
      %{luapkgdir}/metrics/default_metrics/tarantool/system.lua
+     %{luapkgdir}/metrics/default_metrics/tarantool/cpu.lua
      %{luapkgdir}/metrics/cartridge.lua
 %dir %{luapkgdir}/metrics/cartridge
      %{luapkgdir}/metrics/cartridge/issues.lua


### PR DESCRIPTION
This PR adds two new default metrics:

`cpu_user_time` - total cpu user time consumption
`cpu_system_time` - total cpu system time consumption

These metrics are slightly similar to those added in #69 but the `getrusage()` function call via ffi is used to get data.
There aren't cpu usage per tarantool threads as in #69 but only for the whole tarantool instance.

It is proposed to add these metrics to the default so that in all the services that we ship we can understand why tarantool broke. 

I didn't forget about

- [ ] Tests
- [x] Changelog
- [x] Documentation (README and rst)
- [x] Rockspec and rpm spec

Close #41
