### PR TITLE
cpu metrics: fix hot reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- cpu metrics hot reload [#228](https://github.com/tarantool/metrics/issues/228)
 
 ## [0.8.0] - 2021-04-13
 ### Added

--- a/metrics/default_metrics/tarantool/cpu.lua
+++ b/metrics/default_metrics/tarantool/cpu.lua
@@ -1,45 +1,49 @@
 local ffi = require('ffi')
 local utils = require('metrics.utils')
 
-if ffi.os == 'OSX' then
-  ffi.cdef[[
-    typedef int32_t suseconds_t;
-    struct timeval {
-      long        tv_sec;     /* seconds */
-      suseconds_t tv_usec;    /* microseconds */
-    };
-  ]]
-else
-  ffi.cdef[[
-    struct timeval {
-      long tv_sec;     /* seconds */
-      long tv_usec;    /* microseconds */
-    };
-  ]]
+if not pcall(ffi.typeof, "struct timeval") then
+    if ffi.os == 'OSX' then
+        ffi.cdef[[
+            typedef int32_t suseconds_t;
+            struct timeval {
+                long        tv_sec;     /* seconds */
+                suseconds_t tv_usec;    /* microseconds */
+            };
+        ]]
+    else
+        ffi.cdef[[
+            struct timeval {
+                long tv_sec;     /* seconds */
+                long tv_usec;    /* microseconds */
+            };
+        ]]
+    end
 end
 
-ffi.cdef[[
-  struct rusage {
-    struct timeval ru_utime; /* user CPU time used */
-    struct timeval ru_stime; /* system CPU time used */
-    long   ru_maxrss;        /* maximum resident set size */
-    long   ru_ixrss;         /* integral shared memory size */
-    long   ru_idrss;         /* integral unshared data size */
-    long   ru_isrss;         /* integral unshared stack size */
-    long   ru_minflt;        /* page reclaims (soft page faults) */
-    long   ru_majflt;        /* page faults (hard page faults) */
-    long   ru_nswap;         /* swaps */
-    long   ru_inblock;       /* block input operations */
-    long   ru_oublock;       /* block output operations */
-    long   ru_msgsnd;        /* IPC messages sent */
-    long   ru_msgrcv;        /* IPC messages received */
-    long   ru_nsignals;      /* signals received */
-    long   ru_nvcsw;         /* voluntary context switches */
-    long   ru_nivcsw;        /* involuntary context switches */
-  };
-  int getrusage(int who, struct rusage *usage);
-  int gettimeofday(struct timeval *tv, struct timezone *tz);
-]]
+if not pcall(ffi.typeof, "struct rusage") then
+    ffi.cdef[[
+        struct rusage {
+            struct timeval ru_utime; /* user CPU time used */
+            struct timeval ru_stime; /* system CPU time used */
+            long   ru_maxrss;        /* maximum resident set size */
+            long   ru_ixrss;         /* integral shared memory size */
+            long   ru_idrss;         /* integral unshared data size */
+            long   ru_isrss;         /* integral unshared stack size */
+            long   ru_minflt;        /* page reclaims (soft page faults) */
+            long   ru_majflt;        /* page faults (hard page faults) */
+            long   ru_nswap;         /* swaps */
+            long   ru_inblock;       /* block input operations */
+            long   ru_oublock;       /* block output operations */
+            long   ru_msgsnd;        /* IPC messages sent */
+            long   ru_msgrcv;        /* IPC messages received */
+            long   ru_nsignals;      /* signals received */
+            long   ru_nvcsw;         /* voluntary context switches */
+            long   ru_nivcsw;        /* involuntary context switches */
+        };
+        int getrusage(int who, struct rusage *usage);
+        int gettimeofday(struct timeval *tv, struct timezone *tz);
+    ]]
+end
 
 local RUSAGE_SELF = 0
 

--- a/test/integration/hotreload_test.lua
+++ b/test/integration/hotreload_test.lua
@@ -3,10 +3,10 @@ require('strict').on()
 local t = require("luatest")
 local g = t.group('hotreload')
 
-g.test_cpu_reloads = function()
+g.test_cpu_hotreload = function()
     require('metrics.default_metrics.tarantool.cpu')
     for k in pairs(package.loaded) do
-        if k:find('metrics') ~= nil then
+        if k:find('cpu') ~= nil then
             package.loaded[k] = nil
         end
     end

--- a/test/integration/hotreload_test.lua
+++ b/test/integration/hotreload_test.lua
@@ -1,0 +1,14 @@
+require('strict').on()
+
+local t = require("luatest")
+local g = t.group('hotreload')
+
+g.test_cpu_reloads = function()
+    require('metrics.default_metrics.tarantool.cpu')
+    for k in pairs(package.loaded) do
+        if k:find('metrics') ~= nil then
+            package.loaded[k] = nil
+        end
+    end
+    require('metrics.default_metrics.tarantool.cpu')
+end


### PR DESCRIPTION
CPU  metrics breaks hot reload. This caused by `ffi.cdef(struct...)` - multiple calls with same definition results in `attempt to redefine xxx....` error. I introduced guard to check if those variables already defined. 

I didn't forget about

- [x] Tests
- [x] Changelog
- [ ] Documentation (README and rst)
- [ ] Rockspec and rpm spec

Close #228 
