### PR TITLE
Fix http routes removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- be gentle to http routes, don't leave gaps in the array
+  [#246](https://github.com/tarantool/metrics/issues/246)
+
 ## [0.9.0] - 2021-05-28
 ### Fixed
 - cartridge metrics role fails to start without http [#225](https://github.com/tarantool/metrics/issues/225)

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -43,8 +43,16 @@ local function check_config(_)
 end
 
 local function delete_route(httpd, name)
-    httpd.routes[httpd.iroutes[name]] = nil
+    local route = assert(httpd.iroutes[name])
     httpd.iroutes[name] = nil
+    table.remove(httpd.routes, route)
+
+    -- Update httpd.iroutes numeration
+    for n, r in ipairs(httpd.routes) do
+        if r.name then
+            httpd.iroutes[r.name] = n
+        end
+    end
 end
 
 -- removes '/' from start and end of the path to avoid paths duplication

--- a/test/integration/cartridge_role_test.lua
+++ b/test/integration/cartridge_role_test.lua
@@ -139,6 +139,17 @@ g.test_role_add_metrics_http_endpoint = function()
         }
     })
     t.assert_equals(resp.status, 200)
+
+    g.cluster.main_server.net_box:eval([[
+        local cartridge = require('cartridge')
+        local httpd = cartridge.service_get('httpd')
+        for i = 1, table.maxn(httpd.routes) do
+            if httpd.routes[i] == nil then
+                error(('There is a gap in httpd.route[%d]'):format(i))
+            end
+        end
+    ]])
+
     resp = server:http_request('get', '/metrics', {raise = false})
     t.assert_equals(resp.status, 404)
     resp = server:http_request('get', '/new-metrics', {raise = false})


### PR DESCRIPTION
The metrics role handles http router incorrectly - it leaves gaps in the routes table. This patch fixes it.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rest) - unnecessary
- [x] Rockspec and rpm spec - unnecessary

Close #246 
