### PR TITLE
Add box and table globals to .luacheckrc

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,3 +2,4 @@ include_files = {"**/*.lua", "*.rockspec", "*.luacheckrc"}
 exclude_files = {"lua_modules/", ".luarocks/", ".rocks/", "tmp/", ".history/"}
 
 max_line_length = 120
+globals = {'box', 'table', 'jit', 'unpack', 'debug'}


### PR DESCRIPTION
Add `box` and `table` globals to .luacheckrc to avoid warning "accessing undefined variable".