### PR TITLE
Duplicated code in cartridge tests moved to helpers

### DIFF
--- a/test/helper.lua
+++ b/test/helper.lua
@@ -2,6 +2,7 @@ require('strict').on()
 
 local fio = require('fio')
 local utils = require('test.utils')
+local t = require('luatest')
 local ok, cartridge_helpers = pcall(require, 'cartridge.test-helpers')
 if not ok then
     return nil
@@ -60,7 +61,6 @@ function helpers.upload_config(cluster)
 end
 
 function helpers.check_cartridge_version(version)
-    local t = require('luatest')
     local cartridge_version = require('cartridge.VERSION')
     t.skip_if(cartridge_version == 'unknown', 'Cartridge version is unknown, must be v' .. version .. ' or greater')
     t.skip_if(utils.is_version_less(cartridge_version, version),

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -22,9 +22,8 @@ function helpers.entrypoint(name)
     return path
 end
 
-function helpers.init_cluster(t, g)
-    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
-    g.cluster = helpers.Cluster:new({
+function helpers.init_cluster()
+    local cluster = helpers.Cluster:new({
         datadir = fio.tempdir(),
         server_command = helpers.entrypoint('srv_basic'),
         replicasets = {
@@ -38,28 +37,26 @@ function helpers.init_cluster(t, g)
             },
         },
     })
-    g.cluster:start()
-    return g.cluster
+    cluster:start()
+    return cluster
 end
 
 function helpers.upload_config(cluster)
-    return function()
-        local main_server = cluster:server('main')
-        main_server:upload_config({
-            metrics = {
-                export = {
-                    {
-                        path = '/health',
-                        format = 'health'
-                    },
-                    {
-                        path = '/metrics',
-                        format = 'json'
-                    },
+    local main_server = cluster:server('main')
+    main_server:upload_config({
+        metrics = {
+            export = {
+                {
+                    path = '/health',
+                    format = 'health'
                 },
-            }
-        })
-    end
+                {
+                    path = '/metrics',
+                    format = 'json'
+                },
+            },
+        }
+    })
 end
 
 function helpers.check_cartridge_version(version)

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -42,9 +42,8 @@ function helpers.init_cluster()
     return cluster
 end
 
-function helpers.upload_config(cluster)
-    local main_server = cluster:server('main')
-    main_server:upload_config({
+function helpers.upload_default_metrics_config(cluster)
+    cluster:upload_config({
         metrics = {
             export = {
                 {
@@ -60,7 +59,7 @@ function helpers.upload_config(cluster)
     })
 end
 
-function helpers.check_cartridge_version(version)
+function helpers.skip_cartridge_version_less(version)
     local cartridge_version = require('cartridge.VERSION')
     t.skip_if(cartridge_version == 'unknown', 'Cartridge version is unknown, must be v' .. version .. ' or greater')
     t.skip_if(utils.is_version_less(cartridge_version, version),

--- a/test/integration/cartridge_health_test.lua
+++ b/test/integration/cartridge_health_test.lua
@@ -2,65 +2,28 @@ local fio = require('fio')
 local t = require('luatest')
 local g = t.group()
 
-local utils = require('test.utils')
 local helpers = require('test.helper')
 
-g.before_each( function()
-    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
-    g.cluster = helpers.Cluster:new({
-        datadir = fio.tempdir(),
-        server_command = helpers.entrypoint('srv_basic'),
-        replicasets = {
-            {
-                uuid = helpers.uuid('a'),
-                roles = {},
-                servers = {
-                    { instance_uuid = helpers.uuid('a', 1), alias = 'main' },
-                    { instance_uuid = helpers.uuid('b', 1), alias = 'replica' },
-                },
-            },
-        },
-    })
-    g.cluster:start()
-end )
+g.before_each(function()
+    helpers.init_cluster(t, g)
+end)
 
-g.after_each( function()
+g.after_each(function()
     g.cluster:stop()
     fio.rmtree(g.cluster.datadir)
-end )
-
-local function upload_config()
-    local main_server = g.cluster:server('main')
-    main_server:upload_config({
-        metrics = {
-            export = {
-                {
-                    path = '/health',
-                    format = 'health'
-                },
-            },
-        }
-    })
-end
-
-local function check_cartridge_version()
-    -- Health check is compatible cartridge 2.0.2 or greater
-    local cartridge_version = require('cartridge.VERSION')
-    t.skip_if(cartridge_version == 'unknown', 'Cartridge version is unknown, must be v2.0.2 or greater')
-    t.skip_if(utils.is_version_less(cartridge_version, '2.0.2'), 'Cartridge version is must be v2.0.2 or greater')
-end
+end)
 
 g.test_cartridge_health_handler = function()
-    check_cartridge_version()
-    upload_config()
+    helpers.check_cartridge_version('2.0.2')
+    helpers.upload_config(g.cluster)
     local main_server = g.cluster:server('main')
     local resp = main_server:http_request('get', '/health')
     t.assert_equals(resp.status, 200)
 end
 
 g.test_cartridge_health_fail_handler = function()
-    check_cartridge_version()
-    upload_config()
+    helpers.check_cartridge_version('2.0.2')
+    helpers.upload_config(g.cluster)
     local main_server = g.cluster:server('main')
     main_server.net_box:eval([[
         box.info = {

--- a/test/integration/cartridge_health_test.lua
+++ b/test/integration/cartridge_health_test.lua
@@ -5,7 +5,8 @@ local g = t.group()
 local helpers = require('test.helper')
 
 g.before_each(function()
-    helpers.init_cluster(t, g)
+    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
+    g.cluster = helpers.init_cluster()
 end)
 
 g.after_each(function()

--- a/test/integration/cartridge_health_test.lua
+++ b/test/integration/cartridge_health_test.lua
@@ -15,16 +15,16 @@ g.after_each(function()
 end)
 
 g.test_cartridge_health_handler = function()
-    helpers.check_cartridge_version('2.0.2')
-    helpers.upload_config(g.cluster)
+    helpers.skip_cartridge_version_less('2.0.2')
+    helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server('main')
     local resp = main_server:http_request('get', '/health')
     t.assert_equals(resp.status, 200)
 end
 
 g.test_cartridge_health_fail_handler = function()
-    helpers.check_cartridge_version('2.0.2')
-    helpers.upload_config(g.cluster)
+    helpers.skip_cartridge_version_less('2.0.2')
+    helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server('main')
     main_server.net_box:eval([[
         box.info = {

--- a/test/integration/cartridge_hotreload_test.lua
+++ b/test/integration/cartridge_hotreload_test.lua
@@ -6,26 +6,7 @@ local utils = require('test.utils')
 local helpers = require('test.helper')
 
 g.before_each(function()
-    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
-    local cartridge_version = require('cartridge.VERSION')
-    t.skip_if(cartridge_version == 'unknown')
-    t.skip_if(utils.is_version_less(cartridge_version, '2.3.0'))
-    g.cluster = helpers.Cluster:new({
-        datadir = fio.tempdir(),
-        server_command = helpers.entrypoint('srv_basic'),
-        env = {TARANTOOL_ROLES_RELOAD_ALLOWED = 'true'},
-        replicasets = {
-            {
-                uuid = helpers.uuid('a'),
-                roles = {},
-                servers = {
-                    { instance_uuid = helpers.uuid('a', 1), alias = 'main' },
-                    { instance_uuid = helpers.uuid('b', 1), alias = 'replica' },
-                },
-            },
-        },
-    })
-    g.cluster:start()
+    helpers.init_cluster(t, g)
 end)
 
 g.after_each(function()

--- a/test/integration/cartridge_hotreload_test.lua
+++ b/test/integration/cartridge_hotreload_test.lua
@@ -6,7 +6,8 @@ local utils = require('test.utils')
 local helpers = require('test.helper')
 
 g.before_each(function()
-    helpers.init_cluster(t, g)
+    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
+    g.cluster = helpers.init_cluster()
 end)
 
 g.after_each(function()

--- a/test/integration/cartridge_hotreload_test.lua
+++ b/test/integration/cartridge_hotreload_test.lua
@@ -1,7 +1,6 @@
 local fio = require('fio')
 local t = require('luatest')
 local g = t.group()
-local utils = require('test.utils')
 
 local helpers = require('test.helper')
 

--- a/test/integration/cartridge_hotreload_test.lua
+++ b/test/integration/cartridge_hotreload_test.lua
@@ -6,6 +6,7 @@ local helpers = require('test.helper')
 
 g.before_each(function()
     t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
+    helpers.skip_cartridge_version_less('2.3.0')
     g.cluster = helpers.init_cluster()
 end)
 

--- a/test/integration/cartridge_metrics_test.lua
+++ b/test/integration/cartridge_metrics_test.lua
@@ -6,7 +6,8 @@ local utils = require('test.utils')
 local helpers = require('test.helper')
 
 g.before_each(function()
-    helpers.init_cluster(t, g)
+    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
+    g.cluster = helpers.init_cluster()
 end)
 
 g.after_each(function()

--- a/test/integration/cartridge_metrics_test.lua
+++ b/test/integration/cartridge_metrics_test.lua
@@ -99,7 +99,7 @@ g.test_cartridge_issues_metric_critical = function()
 end
 
 g.test_clock_delta_metric_present = function()
-    upload_config()
+    helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server('main')
 
     t.helpers.retrying({}, function()

--- a/test/integration/cartridge_metrics_test.lua
+++ b/test/integration/cartridge_metrics_test.lua
@@ -22,8 +22,8 @@ local function check_cartridge_less_250()
 end
 
 g.test_cartridge_issues_present_on_healthy_cluster = function()
-    helpers.check_cartridge_version('2.0.2')
-    helpers.upload_config(g.cluster)
+    helpers.skip_cartridge_version_less('2.0.2')
+    helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server('main')
     local resp = main_server:http_request('get', '/metrics')
     local issues_metric = utils.find_metric('tnt_cartridge_issues', resp.json)
@@ -39,11 +39,11 @@ g.test_cartridge_issues_present_on_healthy_cluster = function()
 end
 
 g.test_cartridge_issues_metric_warning = function()
-    helpers.check_cartridge_version('2.0.2')
+    helpers.skip_cartridge_version_less('2.0.2')
 
     local main_server = g.cluster:server('main')
     local replica_server = g.cluster:server('replica')
-    helpers.upload_config(g.cluster)
+    helpers.upload_default_metrics_config(g.cluster)
 
     -- Stage replication issue "Duplicate key exists in unique index 'primary' in space '_space'"
     main_server.net_box:eval([[
@@ -73,8 +73,8 @@ g.test_cartridge_issues_metric_warning = function()
 end
 
 g.test_cartridge_issues_metric_critical = function()
-    helpers.check_cartridge_version('2.0.2')
-    helpers.upload_config(g.cluster)
+    helpers.skip_cartridge_version_less('2.0.2')
+    helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server('main')
 
     main_server.net_box:eval([[

--- a/test/integration/cartridge_nohttp_test.lua
+++ b/test/integration/cartridge_nohttp_test.lua
@@ -16,24 +16,8 @@ local function set_export(cluster, export)
     ]], {export})
 end
 
-
 g.test_http_disabled = function()
-    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
-    local cluster = helpers.Cluster:new({
-        datadir = fio.tempdir(),
-        server_command = helpers.entrypoint('srv_basic'),
-        replicasets = {
-            {
-                uuid = helpers.uuid('a'),
-                roles = {},
-                servers = {
-                    {instance_uuid = helpers.uuid('a', 1), alias = 'main'},
-                },
-            },
-        },
-    })
-    cluster:start()
-
+    local cluster = helpers.init_cluster(t, g)
     local server = cluster.main_server
 
     server.net_box:eval([[

--- a/test/integration/cartridge_nohttp_test.lua
+++ b/test/integration/cartridge_nohttp_test.lua
@@ -17,7 +17,7 @@ local function set_export(cluster, export)
 end
 
 g.test_http_disabled = function()
-    local cluster = helpers.init_cluster(t, g)
+    local cluster = helpers.init_cluster()
     local server = cluster.main_server
 
     server.net_box:eval([[

--- a/test/integration/cartridge_nohttp_test.lua
+++ b/test/integration/cartridge_nohttp_test.lua
@@ -17,6 +17,7 @@ local function set_export(cluster, export)
 end
 
 g.test_http_disabled = function()
+    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
     local cluster = helpers.init_cluster()
     local server = cluster.main_server
 

--- a/test/integration/cartridge_role_test.lua
+++ b/test/integration/cartridge_role_test.lua
@@ -79,21 +79,7 @@ end
 
 
 g.before_each(function()
-    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
-    g.cluster = helpers.Cluster:new({
-        datadir = fio.tempdir(),
-        server_command = helpers.entrypoint('srv_basic'),
-        replicasets = {
-            {
-                uuid = helpers.uuid('a'),
-                roles = {},
-                servers = {
-                    {instance_uuid = helpers.uuid('a', 1), alias = 'main'},
-                },
-            },
-        },
-    })
-    g.cluster:start()
+    helpers.init_cluster(t, g)
 end)
 
 g.after_each( function()

--- a/test/integration/cartridge_role_test.lua
+++ b/test/integration/cartridge_role_test.lua
@@ -79,7 +79,8 @@ end
 
 
 g.before_each(function()
-    helpers.init_cluster(t, g)
+    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
+    g.cluster = helpers.init_cluster()
 end)
 
 g.after_each( function()

--- a/test/integration/cartridge_role_test.lua
+++ b/test/integration/cartridge_role_test.lua
@@ -430,7 +430,7 @@ local function set_zones(zones)
     ]], {servers})
 end
 
-local function check_cartridge_version(version)
+local function skip_cartridge_version_less(version)
     local cartridge_version = require('cartridge.VERSION')
     t.skip_if(cartridge_version == 'unknown',
     'Cartridge version is unknown, must be 2.0.2 or greater')
@@ -439,7 +439,7 @@ local function check_cartridge_version(version)
 end
 
 g.test_zone_label_present = function()
-    check_cartridge_version('2.4.0')
+    skip_cartridge_version_less('2.4.0')
     local server = g.cluster.main_server
 
     local ok, err = set_zones({
@@ -459,7 +459,7 @@ g.test_zone_label_present = function()
 end
 
 g.test_zone_label_changes_in_runtime = function()
-    check_cartridge_version('2.4.0')
+    skip_cartridge_version_less('2.4.0')
     local server = g.cluster.main_server
     assert_upload_metrics_config('/metrics')
 


### PR DESCRIPTION
Duplicated functions (cluster initialization, config uploading, version checks) moved to helpers module.

Close #240 
