### PR TITLE
Fix broken tests while repeat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test: .rocks
 .PHONY: test_with_coverage_report
 test_with_coverage_report: .rocks
 	rm -f tmp/luacov.*.out*
-	.rocks/bin/luatest --coverage -v --shuffle group
+	.rocks/bin/luatest --coverage -v --shuffle group --repeat 3
 	.rocks/bin/luacov .
 	echo
 	grep -A999 '^Summary' tmp/luacov.report.out

--- a/doc/monitoring/plugins.rst
+++ b/doc/monitoring/plugins.rst
@@ -136,14 +136,6 @@ To start automatically exporting the current values of all
 
     Exported metric name is sent in the format ``<prefix>.<metric_name>``.
 
-    .. NOTE::
-
-        ``graphite.init()`` function creates fiber with name 'metrics_graphite_worker'
-        and kills all previously started fibers with that name, but those fibers
-        will be killed only after the next yield. Make sure that you're calling
-        ``graphite.init()`` only once.
-
-
 .. _json:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/monitoring/plugins.rst
+++ b/doc/monitoring/plugins.rst
@@ -136,6 +136,14 @@ To start automatically exporting the current values of all
 
     Exported metric name is sent in the format ``<prefix>.<metric_name>``.
 
+    .. NOTE::
+
+        ``graphite.init()`` function creates fiber with name 'metrics_graphite_worker'
+        and kills all previously started fibers with that name, but those fibers
+        will be killed only after the next yield. Make sure that you're calling
+        ``graphite.init()`` only once.
+
+
 .. _json:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/plugins/graphite_test.lua
+++ b/test/plugins/graphite_test.lua
@@ -119,12 +119,13 @@ end
 g.test_graphite_kills_previous_fibers_on_init = function()
     mock_graphite_worker()
     mock_graphite_worker()
+    fiber.sleep(0.5) -- wait to kill previous fibers
     local workers_cnt = count_workers()
     t.assert_equals(workers_cnt, 2)
 
     graphite.init({})
 
-    fiber.sleep(0.5)
+    fiber.sleep(0.5) -- wait to kill previous fibers
     workers_cnt = count_workers()
     t.assert_equals(workers_cnt, 1)
 end

--- a/test/tarantool/vinyl_test.lua
+++ b/test/tarantool/vinyl_test.lua
@@ -11,15 +11,18 @@ g.after_each(function()
     metrics.clear()
 end)
 
+g.before_each(function()
+    -- Enable default metrics collections
+    metrics.enable_default_metrics()
+end)
+
 g.before_all(function()
+    box.cfg{}
     local s_vinyl = box.schema.space.create(
         'test_space',
         {if_not_exists = true, engine = 'vinyl'})
     s_vinyl:create_index('pk', {if_not_exists = true})
     metrics.clear()
-
-    -- Enable default metrics collections
-    metrics.enable_default_metrics()
 end)
 
 g.test_vinyl_metrics_present = function()


### PR DESCRIPTION
Tests doesn't work with repeat option. We need to fix:

- [x] graphite test - no call of socket:close() and no waiting until previous graphite workers will be killed
- [x] vinyl test - metrics.clear() call removed registered callbacks 

I didn't forget about

- [x] Tests

Close #224 
