### PR TITLE
Added configuration of global labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `tnt_clock_delta` metric to compute clock difference on instances
+- set custom global labels in config and with `set_labels` function [#259](https://github.com/tarantool/metrics/issues/259)
 
 ## [0.9.0] - 2021-05-28
 ### Fixed

--- a/doc/monitoring/getting_started.rst
+++ b/doc/monitoring/getting_started.rst
@@ -201,3 +201,20 @@ via configuration.
    .. image:: images/role-config.png
       :align: center
 
+#. To set custom global labels, you may use the following configuration.
+
+   ..  code-block:: yaml
+
+       metrics:
+         export:
+         - path: '/metrics'
+           format: 'json'
+         global-labels:
+           my-custom-label: label-value
+
+   **OR** use ``set_labels`` function in ``init.lua``.
+
+   ..  code-block:: lua
+
+       local metrics = require('cartridge.roles.metrics')
+       metrics.set_labels({ ['my-custom-label'] = 'label-value'} )

--- a/test/integration/cartridge_hotreload_test.lua
+++ b/test/integration/cartridge_hotreload_test.lua
@@ -150,6 +150,69 @@ g.test_cartridge_hotreload_set_labels = function()
     for _, obs in pairs(resp.json) do
         t.assert_equals(obs.label_pairs.system, 'some-system')
         t.assert_equals(obs.label_pairs.app_name, 'myapp')
-        t.assert(obs.label_pairs.alias ~= nil)
+        t.assert_equals(obs.label_pairs.alias, 'main')
+    end
+end
+
+g.test_cartridge_hotreload_labels_from_config = function()
+    local main_server = g.cluster:server('main')
+    main_server:upload_config({
+        metrics = {
+            export = {
+                {
+                    path = '/metrics',
+                    format = 'json'
+                },
+            },
+            ['global-labels'] = {
+                system = 'some-system',
+                app_name = 'myapp',
+            }
+        }
+    })
+
+    reload_roles()
+
+    local resp = main_server:http_request('get', '/metrics', {raise = false})
+    t.assert_equals(resp.status, 200)
+
+    for _, obs in pairs(resp.json) do
+        t.assert_equals(obs.label_pairs.system, 'some-system')
+        t.assert_equals(obs.label_pairs.app_name, 'myapp')
+        t.assert_equals(obs.label_pairs.alias, 'main')
+    end
+end
+
+g.test_cartridge_hotreload_labels_from_config_and_set_labels = function()
+    local main_server = g.cluster:server('main')
+    main_server:upload_config({
+        metrics = {
+            export = {
+                {
+                    path = '/metrics',
+                    format = 'json'
+                },
+            },
+            ['global-labels'] = {
+                system = 'some-system',
+            }
+        }
+    })
+    main_server.net_box:eval([[
+        local metrics = require('cartridge.roles.metrics')
+        metrics.set_default_labels(...)
+    ]], {{
+        app_name = 'myapp',
+    }})
+
+    reload_roles()
+
+    local resp = main_server:http_request('get', '/metrics', {raise = false})
+    t.assert_equals(resp.status, 200)
+
+    for _, obs in pairs(resp.json) do
+        t.assert_equals(obs.label_pairs.system, 'some-system')
+        t.assert_equals(obs.label_pairs.app_name, 'myapp')
+        t.assert_equals(obs.label_pairs.alias, 'main')
     end
 end

--- a/test/integration/cartridge_hotreload_test.lua
+++ b/test/integration/cartridge_hotreload_test.lua
@@ -132,3 +132,24 @@ g.test_cartridge_hotreload_set_export_and_config = function()
     resp = main_server:http_request('get', '/metrics', {raise = false})
     t.assert_equals(resp.status, 200)
 end
+
+g.test_cartridge_hotreload_set_labels = function()
+    local main_server = g.cluster:server('main')
+    main_server.net_box:eval([[
+        local metrics = require('cartridge.roles.metrics')
+        metrics.set_default_labels(...)
+    ]], {{
+        system = 'some-system',
+        app_name = 'myapp',
+    }})
+    reload_roles()
+
+    local resp = main_server:http_request('get', '/metrics', {raise = false})
+    t.assert_equals(resp.status, 200)
+
+    for _, obs in pairs(resp.json) do
+        t.assert_equals(obs.label_pairs.system, 'some-system')
+        t.assert_equals(obs.label_pairs.app_name, 'myapp')
+        t.assert(obs.label_pairs.alias ~= nil)
+    end
+end


### PR DESCRIPTION
Added:
- new section `global-labels` in config to set custom global labels 
- function `set_default_labels` to set custom global labels in init.lua 

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rst)

Close #259 
