### PR TITLE
Add include and exclude section in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - metrics registry refactoring to search with `O(1)` [#188](https://github.com/tarantool/metrics/issues/188)
 - `ipairs` instead of `pairs` while iteration in `histogram` [#196](https://github.com/tarantool/metrics/issues/196)
 - `set_export` function provide default metrics config to make role reloadable [#248](https://github.com/tarantool/metrics/issues/248)
+- metrics registry refactoring to add and remove callbacks with `O(1)` [#276](https://github.com/tarantool/metrics/issues/276)
 
 ### Fixed
 - be gentle to http routes, don't leave gaps in the array
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - set custom global labels in config and with `set_labels` function [#259](https://github.com/tarantool/metrics/issues/259)
 - allow to include and exclude default metrics in config and in `enable_default_metrics` function
   [#222](https://github.com/tarantool/metrics/issues/222)
+- `unregister_callback` function [#262](https://github.com/tarantool/metrics/issues/262)
 
 ### Deprecated
 - `enable_cartridge_metrics` function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `tnt_clock_delta` metric to compute clock difference on instances
 - set custom global labels in config and with `set_labels` function [#259](https://github.com/tarantool/metrics/issues/259)
+- allow to include and exclude default metrics in config and in `enable_default_metrics` function
+  [#222](https://github.com/tarantool/metrics/issues/222)
+
+### Deprecated
+- `enable_cartridge_metrics` function
 
 ## [0.9.0] - 2021-05-28
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ rpm:
 
 .rocks: metrics-scm-1.rockspec
 	tarantoolctl rocks make
-	tarantoolctl rocks install luatest 0.5.3
+	tarantoolctl rocks install luatest 0.5.0
 	tarantoolctl rocks install luacov 0.13.0
 	tarantoolctl rocks install luacheck 0.25.0
 	if [ -z $(CARTRIDGE_VERSION) ]; then \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ rpm:
 
 .rocks: metrics-scm-1.rockspec
 	tarantoolctl rocks make
-	tarantoolctl rocks install luatest 0.5.0
+	tarantoolctl rocks install luatest 0.5.3
 	tarantoolctl rocks install luacov 0.13.0
 	tarantoolctl rocks install luacheck 0.25.0
 	if [ -z $(CARTRIDGE_VERSION) ]; then \

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -54,7 +54,7 @@ local function check_config(config)
         exclude = '?table',
     })
     if config.include and config.exclude then
-        error("don't use exclude and include section together")
+        error("don't use exclude and include sections together", 0)
     end
 end
 

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -157,9 +157,7 @@ local function apply_config(conf)
         end
     end
     apply_routes(paths)
-    metrics.clear()
     metrics.enable_default_metrics(metrics_conf.include, metrics_conf.exclude)
-    metrics.enable_cartridge_metrics()
     set_labels(metrics_conf['global-labels'])
 end
 
@@ -194,7 +192,6 @@ end
 local function init()
     set_labels(metrics_vars.custom_labels)
     metrics.enable_default_metrics()
-    metrics.enable_cartridge_metrics()
     local current_paths = table.copy(metrics_vars.config)
     for path, format in pairs(metrics_vars.default) do
         if current_paths[path] == nil then

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -149,6 +149,7 @@ end
 local function apply_config(conf)
     local metrics_conf = conf.metrics or {}
     metrics_conf.export = metrics_conf.export or {}
+    set_labels(metrics_conf['global-labels'])
     local paths = format_paths(metrics_conf.export)
     metrics_vars.config = table.copy(paths)
     for path, format in pairs(metrics_vars.default) do
@@ -158,7 +159,6 @@ local function apply_config(conf)
     end
     apply_routes(paths)
     metrics.enable_default_metrics(metrics_conf.include, metrics_conf.exclude)
-    set_labels(metrics_conf['global-labels'])
 end
 
 local function set_export(export)

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -266,15 +266,33 @@ You can also set global labels by calling
 Metrics functions
 -------------------------------------------------------------------------------
 
-..  function:: enable_default_metrics()
+..  function:: enable_default_metrics(include, exclude)
 
-    Enables Tarantool metrics collections. See :ref:`metrics reference <metrics-reference>`
-    for details.
+    Enables Tarantool metrics collections.
 
-..  function:: enable_cartridge_metrics()
+    :param table include: Table containing names of default metrics which you need to enable.
 
-    Enables Cartridge metrics collections. See :ref:`metrics reference <metrics-cartridge>`
-    for details.
+    :param table exclude: Table containing names of default metrics which you need to exclude.
+
+    Default metrics names:
+
+    * "network"
+    * "operations"
+    * "system"
+    * "replicas"
+    * "info"
+    * "slab"
+    * "runtime"
+    * "memory"
+    * "spaces"
+    * "fibers"
+    * "cpu"
+    * "vinyl"
+    * "luajit"
+    * "cartridge_issues"
+    * "clock"
+
+    See :ref:`metrics reference <metrics-reference>` for details.
 
 ..  function:: metrics.set_global_labels(label_pairs)
 
@@ -300,6 +318,15 @@ Metrics functions
     :param function callback: Function which takes no parameters.
 
     Most common usage is for gauge metrics updates.
+
+..  function:: unregister_callback(callback)
+
+    Unregisters a function ``callback`` which will be called right before metrics
+    collection on plugin export.
+
+    :param function callback: Function which takes no parameters.
+
+    Most common usage is for unregister enabled callbacks.
 
 .. _collecting-http-statistics:
 

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -266,7 +266,7 @@ You can also set global labels by calling
 Metrics functions
 -------------------------------------------------------------------------------
 
-..  function:: enable_default_metrics(include, exclude)
+..  function:: enable_default_metrics([include, exclude])
 
     Enables Tarantool metrics collections.
 

--- a/doc/monitoring/getting_started.rst
+++ b/doc/monitoring/getting_started.rst
@@ -249,4 +249,4 @@ via configuration.
          - luajit
          - memory
 
-   You can see list of defaul metrics in :ref:`API reference <metrics-functions>`.
+   You can see full list of default metrics in :ref:`API reference <metrics-functions>`.

--- a/doc/monitoring/getting_started.rst
+++ b/doc/monitoring/getting_started.rst
@@ -217,4 +217,36 @@ via configuration.
    ..  code-block:: lua
 
        local metrics = require('cartridge.roles.metrics')
-       metrics.set_labels({ ['my-custom-label'] = 'label-value'} )
+       metrics.set_labels({ ['my-custom-label'] = 'label-value' })
+
+#. To choose which default metrics are exported, you may use the following configuration.
+
+   When you add include section, only metrics from this section are exported:
+
+   ..  code-block:: yaml
+
+       metrics:
+         export:
+         - path: '/metrics'
+           format: 'json'
+         # export only vinyl, luajit and memory metrics:
+         include:
+         - vinyl
+         - luajit
+         - memory
+
+   When you add exclude section, metrics from this section are removed from default metrics list:
+
+   ..  code-block:: yaml
+
+       metrics:
+         export:
+         - path: '/metrics'
+           format: 'json'
+         # export all metrics except vinyl, luajit and memory:
+         exclude:
+         - vinyl
+         - luajit
+         - memory
+
+   You can see list of defaul metrics in :ref:`API reference <metrics-functions>`.

--- a/metrics/cartridge/clock.lua
+++ b/metrics/cartridge/clock.lua
@@ -1,5 +1,9 @@
 local utils = require('metrics.utils')
-local membership = require('membership')
+local ok, membership = pcall(require, 'membership')
+
+if not ok then
+    return { update = function() end }
+end
 
 -- from https://github.com/tarantool/cartridge/blob/cc607f5a6508449608f3953a3f93669e8c8c4ab0/cartridge/issues.lua#L375
 local function update_clock_metrics()

--- a/metrics/cartridge/clock.lua
+++ b/metrics/cartridge/clock.lua
@@ -5,6 +5,8 @@ if not ok then
     return { update = function() end }
 end
 
+local collectors_list = {}
+
 -- from https://github.com/tarantool/cartridge/blob/cc607f5a6508449608f3953a3f93669e8c8c4ab0/cartridge/issues.lua#L375
 local function update_clock_metrics()
 
@@ -23,10 +25,11 @@ local function update_clock_metrics()
         end
     end
 
-    utils.set_gauge('clock_delta', 'Clock difference', min_delta * 1e-6, {delta = 'min'})
-    utils.set_gauge('clock_delta', 'Clock difference', max_delta * 1e-6, {delta = 'max'})
+    collectors_list.clock_delta = utils.set_gauge('clock_delta', 'Clock difference', min_delta * 1e-6, {delta = 'min'})
+    collectors_list.clock_delta = utils.set_gauge('clock_delta', 'Clock difference', max_delta * 1e-6, {delta = 'max'})
 end
 
 return {
-    update = update_clock_metrics
+    update = update_clock_metrics,
+    list = collectors_list,
 }

--- a/metrics/cartridge/issues.lua
+++ b/metrics/cartridge/issues.lua
@@ -1,5 +1,7 @@
-local utils = require('metrics.utils');
+local utils = require('metrics.utils')
 local fun = require('fun')
+
+local collectors_list = {}
 
 local function update_info_metrics()
     local list_on_instance = rawget(_G, '__cartridge_issues_list_on_instance')
@@ -14,11 +16,12 @@ local function update_info_metrics()
 
     for _, level in ipairs(levels) do
         local len = fun.iter(issues):filter(function(x) return x.level == level end):length()
-        utils.set_gauge('cartridge_issues', 'Tarantool Cartridge issues', len, {level = level})
+        collectors_list.cartridge_issues =
+            utils.set_gauge('cartridge_issues', 'Tarantool Cartridge issues', len, {level = level})
     end
-
 end
 
 return {
     update = update_info_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/cpu.lua
+++ b/metrics/default_metrics/tarantool/cpu.lua
@@ -1,6 +1,8 @@
 local ffi = require('ffi')
 local utils = require('metrics.utils')
 
+local collectors_list = {}
+
 if not pcall(ffi.typeof, "struct timeval") then
     if ffi.os == 'OSX' then
         ffi.cdef[[
@@ -68,11 +70,12 @@ end
 local function update_info_metrics()
     local cpu_time = ss_get_rusage()
     if cpu_time then
-        utils.set_gauge('cpu_user_time', 'CPU user time usage', cpu_time.ru_utime)
-        utils.set_gauge('cpu_system_time', 'CPU system time usage', cpu_time.ru_stime)
+        collectors_list.cpu_user_time = utils.set_gauge('cpu_user_time', 'CPU user time usage', cpu_time.ru_utime)
+        collectors_list.cpu_system_time = utils.set_gauge('cpu_system_time', 'CPU system time usage', cpu_time.ru_stime)
     end
 end
 
 return {
     update = update_info_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/fibers.lua
+++ b/metrics/default_metrics/tarantool/fibers.lua
@@ -1,6 +1,8 @@
 local fiber = require('fiber')
 local utils = require('metrics.utils')
 
+local collectors_list = {}
+
 local function update_fibers_metrics()
     local fibers_info = fiber.info()
     local fibers = 0
@@ -15,12 +17,13 @@ local function update_fibers_metrics()
         fused = fused + f.memory.used
     end
 
-    utils.set_gauge('fiber_count', 'Amount of fibers', fibers)
-    utils.set_gauge('fiber_csw', 'Fibers csw', csws)
-    utils.set_gauge('fiber_memalloc', 'Fibers memalloc', falloc)
-    utils.set_gauge('fiber_memused', 'Fibers memused', fused)
+    collectors_list.fiber_count = utils.set_gauge('fiber_count', 'Amount of fibers', fibers)
+    collectors_list.fiber_csw = utils.set_gauge('fiber_csw', 'Fibers csw', csws)
+    collectors_list.fiber_memalloc = utils.set_gauge('fiber_memalloc', 'Fibers memalloc', falloc)
+    collectors_list.fiber_memused = utils.set_gauge('fiber_memused', 'Fibers memused', fused)
 end
 
 return {
     update = update_fibers_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/info.lua
+++ b/metrics/default_metrics/tarantool/info.lua
@@ -1,4 +1,6 @@
-local utils = require('metrics.utils');
+local utils = require('metrics.utils')
+
+local collectors_list = {}
 
 local function update_info_metrics()
     if not utils.box_is_configured() then
@@ -7,8 +9,8 @@ local function update_info_metrics()
 
     local info = box.info()
 
-    utils.set_gauge('info_lsn', 'Tarantool lsn', info.lsn)
-    utils.set_gauge('info_uptime', 'Tarantool uptime', info.uptime)
+    collectors_list.info_lsn = utils.set_gauge('info_lsn', 'Tarantool lsn', info.lsn)
+    collectors_list.info_uptime = utils.set_gauge('info_uptime', 'Tarantool uptime', info.uptime)
 
     for k, v in ipairs(info.vclock) do
         utils.set_gauge('info_vclock', 'VClock', v, {id = k})
@@ -16,11 +18,14 @@ local function update_info_metrics()
 
     for k, v in ipairs(info.replication) do
         if v.upstream ~= nil then
-            utils.set_gauge('replication_' .. k .. '_lag', 'Replication lag for instance ' .. k, v.upstream.lag)
+            local metric_name = 'replication_' .. k .. '_lag'
+            collectors_list[metric_name] =
+                utils.set_gauge(metric_name, 'Replication lag for instance ' .. k, v.upstream.lag)
         end
     end
 end
 
 return {
     update = update_info_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/init.lua
+++ b/metrics/default_metrics/tarantool/init.lua
@@ -1,23 +1,36 @@
 local metrics = require('metrics')
 
 local default_metrics = {
-    require('metrics.default_metrics.tarantool.network'),
-    require('metrics.default_metrics.tarantool.operations'),
-    require('metrics.default_metrics.tarantool.system'),
-    require('metrics.default_metrics.tarantool.replicas'),
-    require('metrics.default_metrics.tarantool.info'),
-    require('metrics.default_metrics.tarantool.slab'),
-    require('metrics.default_metrics.tarantool.runtime'),
-    require('metrics.default_metrics.tarantool.memory'),
-    require('metrics.default_metrics.tarantool.spaces'),
-    require('metrics.default_metrics.tarantool.fibers'),
-    require('metrics.default_metrics.tarantool.cpu'),
-    require('metrics.tarantool.vinyl')
+    network = require('metrics.default_metrics.tarantool.network'),
+    operations = require('metrics.default_metrics.tarantool.operations'),
+    system = require('metrics.default_metrics.tarantool.system'),
+    replicas = require('metrics.default_metrics.tarantool.replicas'),
+    info = require('metrics.default_metrics.tarantool.info'),
+    slab = require('metrics.default_metrics.tarantool.slab'),
+    runtime = require('metrics.default_metrics.tarantool.runtime'),
+    memory = require('metrics.default_metrics.tarantool.memory'),
+    spaces = require('metrics.default_metrics.tarantool.spaces'),
+    fibers = require('metrics.default_metrics.tarantool.fibers'),
+    cpu = require('metrics.default_metrics.tarantool.cpu'),
+    vinyl = require('metrics.tarantool.vinyl'),
+    luajit = require('metrics.tarantool.luajit'),
 }
 
-local function enable()
-    for _, metric in ipairs(default_metrics) do
-        metrics.register_callback(metric.update)
+local function enable(include, exclude)
+    local exclude_map = {}
+    for _, name in ipairs(exclude or {}) do
+        exclude_map[name] = true
+    end
+    if include then
+        for _, name in ipairs(include) do
+            metrics.register_callback(default_metrics[name].update)
+        end
+    else
+        for name, metric in pairs(default_metrics) do
+            if not exclude_map[name] then
+                metrics.register_callback(metric.update)
+            end
+        end
     end
 end
 

--- a/metrics/default_metrics/tarantool/init.lua
+++ b/metrics/default_metrics/tarantool/init.lua
@@ -19,9 +19,13 @@ local default_metrics = {
 }
 
 local function delete_collectors(list)
+    if list == nil then
+        return
+    end
     for _, collector in pairs(list) do
         metrics.registry:unregister(collector)
     end
+    table.clear(list)
 end
 
 local function enable(include, exclude)

--- a/metrics/default_metrics/tarantool/init.lua
+++ b/metrics/default_metrics/tarantool/init.lua
@@ -1,26 +1,35 @@
 local metrics = require('metrics')
 
 local default_metrics = {
-    network = require('metrics.default_metrics.tarantool.network'),
-    operations = require('metrics.default_metrics.tarantool.operations'),
-    system = require('metrics.default_metrics.tarantool.system'),
-    replicas = require('metrics.default_metrics.tarantool.replicas'),
-    info = require('metrics.default_metrics.tarantool.info'),
-    slab = require('metrics.default_metrics.tarantool.slab'),
-    runtime = require('metrics.default_metrics.tarantool.runtime'),
-    memory = require('metrics.default_metrics.tarantool.memory'),
-    spaces = require('metrics.default_metrics.tarantool.spaces'),
-    fibers = require('metrics.default_metrics.tarantool.fibers'),
-    cpu = require('metrics.default_metrics.tarantool.cpu'),
-    vinyl = require('metrics.tarantool.vinyl'),
-    luajit = require('metrics.tarantool.luajit'),
-    cartridge_issues = require('metrics.cartridge.issues'),
-    clock = require('metrics.cartridge.clock'),
+    network             = require('metrics.default_metrics.tarantool.network'),
+    operations          = require('metrics.default_metrics.tarantool.operations'),
+    system              = require('metrics.default_metrics.tarantool.system'),
+    replicas            = require('metrics.default_metrics.tarantool.replicas'),
+    info                = require('metrics.default_metrics.tarantool.info'),
+    slab                = require('metrics.default_metrics.tarantool.slab'),
+    runtime             = require('metrics.default_metrics.tarantool.runtime'),
+    memory              = require('metrics.default_metrics.tarantool.memory'),
+    spaces              = require('metrics.default_metrics.tarantool.spaces'),
+    fibers              = require('metrics.default_metrics.tarantool.fibers'),
+    cpu                 = require('metrics.default_metrics.tarantool.cpu'),
+    vinyl               = require('metrics.tarantool.vinyl'),
+    luajit              = require('metrics.tarantool.luajit'),
+    cartridge_issues    = require('metrics.cartridge.issues'),
+    clock               = require('metrics.cartridge.clock'),
 }
+
+local function delete_collectors(list)
+    for _, collector in pairs(list) do
+        metrics.registry:unregister(collector)
+    end
+end
 
 local function enable(include, exclude)
     include = include or {}
     exclude = exclude or {}
+    if next(include) ~= nil and next(exclude) ~= nil then
+        error('Only one of "exclude" or "include" should present')
+    end
 
     local exclude_map = {}
     for _, name in ipairs(exclude) do
@@ -32,15 +41,17 @@ local function enable(include, exclude)
     end
 
     for name, value in pairs(default_metrics) do
-        if #include > 0 then
+        if next(include) ~= nil then
             if include_map[name] ~= nil then
                 metrics.register_callback(value.update)
             else
                 metrics.unregister_callback(value.update)
+                delete_collectors(value.list)
             end
-        elseif #exclude > 0 then
+        elseif next(exclude) ~= nil then
             if exclude_map[name] ~= nil then
                 metrics.unregister_callback(value.update)
+                delete_collectors(value.list)
             else
                 metrics.register_callback(value.update)
             end

--- a/metrics/default_metrics/tarantool/memory.lua
+++ b/metrics/default_metrics/tarantool/memory.lua
@@ -1,5 +1,7 @@
 local utils = require('metrics.utils')
 
+local collectors_list = {}
+
 local function update_memory_metrics()
     if not utils.box_is_configured() then
         return
@@ -8,11 +10,13 @@ local function update_memory_metrics()
     if box.info.memory ~= nil then
         local i = box.info.memory()
         for k, v in pairs(i) do
-            utils.set_gauge('info_memory_' .. k, 'Memory' .. k, v)
+            local metric_name = 'info_memory_' .. k
+            collectors_list[metric_name] = utils.set_gauge(metric_name, 'Memory' .. k, v)
         end
     end
 end
 
 return {
-    update = update_memory_metrics
+    update = update_memory_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/memory.lua
+++ b/metrics/default_metrics/tarantool/memory.lua
@@ -11,7 +11,7 @@ local function update_memory_metrics()
         local i = box.info.memory()
         for k, v in pairs(i) do
             local metric_name = 'info_memory_' .. k
-            collectors_list[metric_name] = utils.set_gauge(metric_name, 'Memory' .. k, v)
+            collectors_list[metric_name] = utils.set_gauge(metric_name, 'Memory ' .. k, v)
         end
     end
 end

--- a/metrics/default_metrics/tarantool/network.lua
+++ b/metrics/default_metrics/tarantool/network.lua
@@ -1,5 +1,6 @@
 local utils = require('metrics.utils')
 
+local collectors_list = {}
 
 local function update_network_metrics()
     if not utils.box_is_configured() then
@@ -8,30 +9,42 @@ local function update_network_metrics()
 
     local box_stat_net = box.stat.net()
 
-    utils.set_gauge('net_sent_total', 'Totally sent in bytes', box_stat_net.SENT.total)
-    utils.set_gauge('net_sent_rps', 'Sending RPS', box_stat_net.SENT.rps)
-    utils.set_gauge('net_received_total', 'Totally received in bytes', box_stat_net.RECEIVED.total)
-    utils.set_gauge('net_received_rps', 'Receive RPS', box_stat_net.RECEIVED.rps)
+    collectors_list.net_sent_total =
+        utils.set_gauge('net_sent_total', 'Totally sent in bytes', box_stat_net.SENT.total)
+    collectors_list.net_sent_rps =
+        utils.set_gauge('net_sent_rps', 'Sending RPS', box_stat_net.SENT.rps)
+    collectors_list.net_received_total =
+        utils.set_gauge('net_received_total', 'Totally received in bytes', box_stat_net.RECEIVED.total)
+    collectors_list.net_received_rps =
+        utils.set_gauge('net_received_rps', 'Receive RPS', box_stat_net.RECEIVED.rps)
 
     -- https://github.com/tarantool/doc/issues/760
 
     -- before tnt version 2.2.0
     if box_stat_net.CONNECTIONS ~= nil and type(box_stat_net.CONNECTIONS) ~= 'number' then
-        utils.set_gauge('net_connections_rps', 'Connection RPS', box_stat_net.CONNECTIONS.rps)
-        utils.set_gauge('net_connections_total', 'Connections total amount', box_stat_net.CONNECTIONS.total)
-        utils.set_gauge('net_connections_current', 'Current connections amount', box_stat_net.CONNECTIONS.current)
+        collectors_list.net_connections_rps =
+            utils.set_gauge('net_connections_rps', 'Connection RPS', box_stat_net.CONNECTIONS.rps)
+        collectors_list.net_connections_total =
+            utils.set_gauge('net_connections_total', 'Connections total amount', box_stat_net.CONNECTIONS.total)
+        collectors_list.net_connections_current =
+            utils.set_gauge('net_connections_current', 'Current connections amount', box_stat_net.CONNECTIONS.current)
     elseif box_stat_net.CONNECTIONS ~= nil then
-        utils.set_gauge('net_connections_current', 'Current connections amount', box_stat_net.CONNECTIONS)
+        collectors_list.net_connections_current =
+            utils.set_gauge('net_connections_current', 'Current connections amount', box_stat_net.CONNECTIONS)
     end
 
     if box_stat_net.REQUESTS ~= nil then
-        utils.set_gauge('net_requests_rps', 'Requests RPS', box_stat_net.REQUESTS.rps)
-        utils.set_gauge('net_requests_total', 'Requests total amount', box_stat_net.REQUESTS.total)
-        utils.set_gauge('net_requests_current', 'Pending requests', box_stat_net.REQUESTS.current)
+        collectors_list.net_requests_rps =
+            utils.set_gauge('net_requests_rps', 'Requests RPS', box_stat_net.REQUESTS.rps)
+        collectors_list.net_requests_total =
+            utils.set_gauge('net_requests_total', 'Requests total amount', box_stat_net.REQUESTS.total)
+        collectors_list.net_requests_current =
+            utils.set_gauge('net_requests_current', 'Pending requests', box_stat_net.REQUESTS.current)
     end
 end
 
 
 return {
     update = update_network_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/operations.lua
+++ b/metrics/default_metrics/tarantool/operations.lua
@@ -1,5 +1,7 @@
 local utils = require('metrics.utils')
 
+local collectors_list = {}
+
 local function update_operations_metrics()
     if not utils.box_is_configured() then
         return
@@ -8,11 +10,14 @@ local function update_operations_metrics()
     local current_stat = box.stat()
 
     for k, v in pairs(current_stat) do
-        utils.set_gauge('stats_op_total', 'Total amount of operations', v.total, {operation = k:lower()})
-        utils.set_gauge('stats_op_rps', 'Total RPS', v.rps, {operation = k:lower()})
+        collectors_list.stats_op_total =
+            utils.set_gauge('stats_op_total', 'Total amount of operations', v.total, {operation = k:lower()})
+        collectors_list.stats_op_rps =
+            utils.set_gauge('stats_op_rps', 'Total RPS', v.rps, {operation = k:lower()})
     end
 end
 
 return {
-    update = update_operations_metrics
+    update = update_operations_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/replicas.lua
+++ b/metrics/default_metrics/tarantool/replicas.lua
@@ -1,5 +1,6 @@
 local utils = require('metrics.utils')
 
+local collectors_list = {}
 
 local function update_replicas_metrics()
     if not utils.box_is_configured() then
@@ -13,7 +14,8 @@ local function update_replicas_metrics()
             local replication_info = current_box_info.replication[k]
             if replication_info then
                 local lsn = replication_info.lsn
-                utils.set_gauge('replication_replica_' .. k .. '_lsn', 'lsn for replica ' .. k, lsn - v)
+                local metric_name = 'replication_replica_' .. k .. '_lsn'
+                collectors_list[metric_name] = utils.set_gauge(metric_name, 'lsn for replica ' .. k, lsn - v)
             end
         end
     else
@@ -21,10 +23,11 @@ local function update_replicas_metrics()
             if v.downstream ~= nil and v.downstream.vclock ~= nil then
                 local lsn = v.downstream.vclock[current_box_info.id]
                 if lsn ~= nil and current_box_info.lsn ~= nil then
-                    utils.set_gauge(
-                            'replication_master_' .. k .. '_lsn',
-                            'lsn for master ' .. k,
-                            current_box_info.lsn - lsn
+                    local metric_name = 'replication_master_' .. k .. '_lsn'
+                    collectors_list[metric_name] = utils.set_gauge(
+                        metric_name,
+                        'lsn for master ' .. k,
+                        current_box_info.lsn - lsn
                     )
                 end
             end
@@ -33,5 +36,6 @@ local function update_replicas_metrics()
 end
 
 return {
-    update = update_replicas_metrics
+    update = update_replicas_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/runtime.lua
+++ b/metrics/default_metrics/tarantool/runtime.lua
@@ -1,15 +1,19 @@
 local utils = require('metrics.utils')
 
+local collectors_list = {}
+
 local function update_runtime_metrics()
     local runtime_info = box.runtime.info()
 
     for k, v in pairs(runtime_info) do
         if k ~= 'maxalloc' then
-            utils.set_gauge('runtime_' .. k, 'Runtime ' .. k, v)
+            local metric_name = 'runtime_' .. k
+            collectors_list[metric_name] = utils.set_gauge(metric_name, 'Runtime ' .. k, v)
         end
     end
 end
 
 return {
     update = update_runtime_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/slab.lua
+++ b/metrics/default_metrics/tarantool/slab.lua
@@ -1,5 +1,7 @@
 local utils = require('metrics.utils')
 
+local collectors_list = {}
+
 local function update_slab_metrics()
     if not utils.box_is_configured() then
         return
@@ -8,14 +10,17 @@ local function update_slab_metrics()
     local slab_info = box.slab.info()
 
     for k, v in pairs(slab_info) do
+        local metric_name = 'slab_' .. k
         if not k:match('_ratio$') then
-            utils.set_gauge('slab_' .. k, 'Slab ' .. k .. ' info', v)
+            collectors_list[metric_name] = utils.set_gauge(metric_name, 'Slab ' .. k .. ' info', v)
         else
-            utils.set_gauge('slab_' .. k, 'Slab ' .. k .. ' info', tonumber(v:match('^([0-9%.]+)%%?$')))
+            collectors_list[metric_name] =
+                utils.set_gauge(metric_name, 'Slab ' .. k .. ' info', tonumber(v:match('^([0-9%.]+)%%?$')))
         end
     end
 end
 
 return {
-    update = update_slab_metrics
+    update = update_slab_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/spaces.lua
+++ b/metrics/default_metrics/tarantool/spaces.lua
@@ -1,5 +1,7 @@
 local utils = require('metrics.utils')
 
+local collectors_list = {}
+
 local function update_spaces_metrics()
     if not utils.box_is_configured() then
         return
@@ -19,7 +21,8 @@ local function update_spaces_metrics()
                 if type(space_id) == 'number' then
                     local l = table.copy(labels)
                     l.index_name = i.name
-                    utils.set_gauge('space_index_bsize', 'Index bsize', i:bsize(), l)
+                    collectors_list.space_index_bsize =
+                        utils.set_gauge('space_index_bsize', 'Index bsize', i:bsize(), l)
                     total = total + i:bsize()
                 end
             end
@@ -29,18 +32,21 @@ local function update_spaces_metrics()
 
                 labels.engine = 'memtx'
 
-                utils.set_gauge('space_len' , 'Space length', sp:len(), labels)
+                collectors_list.space_len =
+                    utils.set_gauge('space_len' , 'Space length', sp:len(), labels)
 
-                utils.set_gauge('space_bsize', 'Space bsize', sp_bsize, labels)
+                collectors_list.space_bsize =
+                    utils.set_gauge('space_bsize', 'Space bsize', sp_bsize, labels)
 
-                utils.set_gauge('space_total_bsize', 'Space total bsize', sp_bsize + total, labels)
+                collectors_list.space_total_bsize =
+                    utils.set_gauge('space_total_bsize', 'Space total bsize', sp_bsize + total, labels)
 
             else
                 labels.engine = 'vinyl'
 
                 local include_vinyl_count = rawget(_G, 'include_vinyl_count') or false
                 if include_vinyl_count then
-                    utils.set_gauge( 'space_count', 'Space count', sp:count(), labels)
+                    collectors_list.space_count = utils.set_gauge('space_count', 'Space count', sp:count(), labels)
                 end
             end
         end
@@ -49,4 +55,5 @@ end
 
 return {
     update = update_spaces_metrics,
+    list = collectors_list,
 }

--- a/metrics/default_metrics/tarantool/system.lua
+++ b/metrics/default_metrics/tarantool/system.lua
@@ -1,14 +1,17 @@
 local utils = require('metrics.utils')
 local clock = require('clock')
 
+local collectors_list = {}
+
 local function update_system_metrics()
     if not utils.box_is_configured() then
         return
     end
 
-    utils.set_gauge('cfg_current_time', 'Tarantool cfg time', clock.time() + 0ULL)
+    collectors_list.cfg_current_time = utils.set_gauge('cfg_current_time', 'Tarantool cfg time', clock.time() + 0ULL)
 end
 
 return {
     update = update_system_metrics,
+    list = collectors_list,
 }

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -1,6 +1,7 @@
 -- vim: ts=4:sw=4:sts=4:expandtab
 
 local checks = require('checks')
+local log = require('log')
 
 local Registry = require('metrics.registry')
 
@@ -21,6 +22,10 @@ end
 
 local function register_callback(...)
     return registry:register_callback(...)
+end
+
+local function unregister_callback(...)
+    return registry:unregister_callback(...)
 end
 
 local function invoke_callbacks()
@@ -109,12 +114,14 @@ return {
     clear = clear,
     collectors = collectors,
     register_callback = register_callback,
+    unregister_callback = unregister_callback,
     invoke_callbacks = invoke_callbacks,
     set_global_labels = set_global_labels,
     enable_default_metrics = function(include, exclude)
         require('metrics.default_metrics.tarantool').enable(include, exclude)
     end,
     enable_cartridge_metrics = function()
+        log.warn('metrics.enable_cartridge_metrics() is deprecated. Use metrics.enable_default_metrics() instead.')
         return require('metrics.cartridge').enable()
     end,
     http_middleware = require('metrics.http_middleware'),

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -111,9 +111,8 @@ return {
     register_callback = register_callback,
     invoke_callbacks = invoke_callbacks,
     set_global_labels = set_global_labels,
-    enable_default_metrics = function()
-        require('metrics.tarantool.luajit').enable()
-        require('metrics.default_metrics.tarantool').enable()
+    enable_default_metrics = function(include, exclude)
+        require('metrics.default_metrics.tarantool').enable(include, exclude)
     end,
     enable_cartridge_metrics = function()
         return require('metrics.cartridge').enable()

--- a/metrics/psutils/cpu.lua
+++ b/metrics/psutils/cpu.lua
@@ -6,21 +6,23 @@ end
 local utils = require('metrics.utils')
 local psutils = require('metrics.psutils.psutils_linux')
 
+local collectors_list = {}
+
 local instance_file = arg[0]
-utils.set_gauge('cpu_count', 'The number of processors', psutils.get_cpu_count())
+collectors_list.cpu_count = utils.set_gauge('cpu_count', 'The number of processors', psutils.get_cpu_count())
 
 local function update_cpu_metrics()
     utils.set_gauge('cpu_total', 'Host CPU time', psutils.get_cpu_time())
 
     for _, thread_info in ipairs(psutils.get_process_cpu_time()) do
-        utils.set_gauge('cpu_thread', 'Tarantool thread cpu time', thread_info.utime, {
+        collectors_list.cpu_thread = utils.set_gauge('cpu_thread', 'Tarantool thread cpu time', thread_info.utime, {
             kind = 'user',
             thread_name = thread_info.comm,
             thread_pid = thread_info.pid,
             file_name = instance_file,
         })
 
-        utils.set_gauge('cpu_thread', 'Tarantool thread cpu time', thread_info.stime, {
+        collectors_list.cpu_thread = utils.set_gauge('cpu_thread', 'Tarantool thread cpu time', thread_info.stime, {
             kind = 'system',
             thread_name = thread_info.comm,
             thread_pid = thread_info.pid,
@@ -31,4 +33,5 @@ end
 
 return {
     update = update_cpu_metrics,
+    list = collectors_list,
 }

--- a/metrics/registry.lua
+++ b/metrics/registry.lua
@@ -43,7 +43,7 @@ function Registry:unregister(collector)
 end
 
 function Registry:invoke_callbacks()
-    for _, registered_callback in ipairs(self.callbacks) do
+    for registered_callback, _ in pairs(self.callbacks) do
         registered_callback()
     end
 end
@@ -59,23 +59,11 @@ function Registry:collect()
 end
 
 function Registry:register_callback(callback)
-    local found = false
-    for _, registered_callback in ipairs(self.callbacks) do
-        if registered_callback == callback then
-            found = true
-        end
-    end
-    if not found then
-        table.insert(self.callbacks, callback)
-    end
+    self.callbacks[callback] = true
 end
 
 function Registry:unregister_callback(callback)
-    for i, registered_callback in ipairs(self.callbacks) do
-        if registered_callback == callback then
-            table.remove(self.callbacks, i)
-        end
-    end
+    self.callbacks[callback] = nil
 end
 
 function Registry:set_labels(label_pairs)

--- a/metrics/registry.lua
+++ b/metrics/registry.lua
@@ -70,6 +70,14 @@ function Registry:register_callback(callback)
     end
 end
 
+function Registry:unregister_callback(callback)
+    for i, registered_callback in ipairs(self.callbacks) do
+        if registered_callback == callback then
+            table.remove(self.callbacks, i)
+        end
+    end
+end
+
 function Registry:set_labels(label_pairs)
     self.label_pairs = table.copy(label_pairs)
 end

--- a/metrics/tarantool/luajit.lua
+++ b/metrics/tarantool/luajit.lua
@@ -13,6 +13,7 @@ end
 local function set_gauge(name, description, value, labels)
     local gauge = metrics.gauge(prefix_name(name), description)
     gauge:set(value, labels or {})
+    return gauge
 end
 
 local function set_counter(name, description, value, labels)
@@ -21,7 +22,10 @@ local function set_counter(name, description, value, labels)
         counter.set = Shared.set
     end
     counter:set(value, labels or {})
+    return counter
 end
+
+local collectors_list = {}
 
 local function update()
     if not (has_mics_module and misc.getmetrics ~= nil) then
@@ -29,46 +33,50 @@ local function update()
     end
     -- Details: https://github.com/tarantool/doc/issues/1597
     local lj_metrics = misc.getmetrics()
-    set_counter('gc_freed', 'Total amount of freed memory',
-        lj_metrics.gc_freed)
-    set_counter('strhash_hit', 'Number of strings being interned',
-        lj_metrics.strhash_hit)
-    set_counter('gc_steps_atomic', 'Count of incremental GC steps (atomic state)',
-        lj_metrics.gc_steps_atomic)
-    set_counter('strhash_miss', 'Total number of strings allocations during the platform lifetime',
-        lj_metrics.strhash_miss)
-    set_counter('gc_steps_sweepstring', 'Count of incremental GC steps (sweepstring state)',
-        lj_metrics.gc_steps_sweepstring)
-    set_gauge('gc_strnum', 'Amount of allocated string objects',
-        lj_metrics.gc_strnum)
-    set_gauge('gc_tabnum', 'Amount of allocated table objects',
-        lj_metrics.gc_tabnum)
-    set_gauge('gc_cdatanum', 'Amount of allocated cdata objects',
-        lj_metrics.gc_cdatanum)
-    set_counter('jit_snap_restore', 'Overall number of snap restores',
-        lj_metrics.jit_snap_restore)
-    set_gauge('gc_total', 'Memory currently allocated',
-        lj_metrics.gc_total)
-    set_gauge('gc_udatanum', 'Amount of allocated udata objects',
-        lj_metrics.gc_udatanum)
-    set_counter('gc_steps_finalize', 'Count of incremental GC steps (finalize state)',
-        lj_metrics.gc_steps_finalize)
-    set_counter('gc_allocated', 'Total amount of allocated memory',
-        lj_metrics.gc_allocated)
-    set_gauge('jit_trace_num', 'Amount of JIT traces',
-        lj_metrics.jit_trace_num)
-    set_counter('gc_steps_sweep', 'Count of incremental GC steps (sweep state)',
-        lj_metrics.gc_steps_sweep)
-    set_counter('jit_trace_abort', 'Overall number of abort traces',
-        lj_metrics.jit_trace_abort)
-    set_gauge('jit_mcode_size', 'Total size of all allocated machine code areas',
-        lj_metrics.jit_mcode_size)
-    set_counter('gc_steps_propagate', 'Count of incremental GC steps (propagate state)',
-        lj_metrics.gc_steps_propagate)
-    set_counter('gc_steps_pause', 'Count of incremental GC steps (pause state)',
-        lj_metrics.gc_steps_pause)
+    collectors_list.gc_freed =
+        set_counter('gc_freed', 'Total amount of freed memory', lj_metrics.gc_freed)
+    collectors_list.strhash_hit =
+        set_counter('strhash_hit', 'Number of strings being interned', lj_metrics.strhash_hit)
+    collectors_list.gc_steps_atomic =
+        set_counter('gc_steps_atomic', 'Count of incremental GC steps (atomic state)', lj_metrics.gc_steps_atomic)
+    collectors_list.strhash_miss =
+        set_counter('strhash_miss', 'Total number of strings allocations during the platform lifetime',
+            lj_metrics.strhash_miss)
+    collectors_list.gc_steps_sweepstring =
+        set_counter('gc_steps_sweepstring', 'Count of incremental GC steps (sweepstring state)',
+            lj_metrics.gc_steps_sweepstring)
+    collectors_list.gc_strnum =
+        set_gauge('gc_strnum', 'Amount of allocated string objects', lj_metrics.gc_strnum)
+    collectors_list.gc_tabnum =
+        set_gauge('gc_tabnum', 'Amount of allocated table objects', lj_metrics.gc_tabnum)
+    collectors_list.gc_cdatanum =
+        set_gauge('gc_cdatanum', 'Amount of allocated cdata objects', lj_metrics.gc_cdatanum)
+    collectors_list.jit_snap_restore =
+        set_counter('jit_snap_restore', 'Overall number of snap restores', lj_metrics.jit_snap_restore)
+    collectors_list.gc_total =
+        set_gauge('gc_total', 'Memory currently allocated', lj_metrics.gc_total)
+    collectors_list.gc_udatanum =
+        set_gauge('gc_udatanum', 'Amount of allocated udata objects', lj_metrics.gc_udatanum)
+    collectors_list.gc_steps_finalize =
+        set_counter('gc_steps_finalize', 'Count of incremental GC steps (finalize state)', lj_metrics.gc_steps_finalize)
+    collectors_list.gc_allocated =
+        set_counter('gc_allocated', 'Total amount of allocated memory', lj_metrics.gc_allocated)
+    collectors_list.jit_trace_num =
+        set_gauge('jit_trace_num', 'Amount of JIT traces', lj_metrics.jit_trace_num)
+    collectors_list.gc_steps_sweep =
+        set_counter('gc_steps_sweep', 'Count of incremental GC steps (sweep state)', lj_metrics.gc_steps_sweep)
+    collectors_list.jit_trace_abort =
+        set_counter('jit_trace_abort', 'Overall number of abort traces', lj_metrics.jit_trace_abort)
+    collectors_list.jit_mcode_size =
+        set_gauge('jit_mcode_size', 'Total size of all allocated machine code areas', lj_metrics.jit_mcode_size)
+    collectors_list.gc_steps_propagate =
+        set_counter('gc_steps_propagate', 'Count of incremental GC steps (propagate state)',
+            lj_metrics.gc_steps_propagate)
+    collectors_list.gc_steps_pause =
+        set_counter('gc_steps_pause', 'Count of incremental GC steps (pause state)', lj_metrics.gc_steps_pause)
 end
 
 return {
     update = update,
+    list = collectors_list,
 }

--- a/metrics/tarantool/luajit.lua
+++ b/metrics/tarantool/luajit.lua
@@ -24,6 +24,9 @@ local function set_counter(name, description, value, labels)
 end
 
 local function update()
+    if not (has_mics_module and misc.getmetrics ~= nil) then
+        return
+    end
     -- Details: https://github.com/tarantool/doc/issues/1597
     local lj_metrics = misc.getmetrics()
     set_counter('gc_freed', 'Total amount of freed memory',
@@ -66,14 +69,6 @@ local function update()
         lj_metrics.gc_steps_pause)
 end
 
-local enable = function() end
-
-if has_mics_module and misc.getmetrics ~= nil then
-    enable = function()
-        metrics.register_callback(update)
-    end
-end
-
 return {
-    enable = enable,
+    update = update,
 }

--- a/metrics/tarantool/vinyl.lua
+++ b/metrics/tarantool/vinyl.lua
@@ -1,45 +1,67 @@
 local utils = require('metrics.utils')
 
+local collectors_list = {}
+
 local function update()
     if not utils.box_is_configured() then
         return
     end
 
     local vinyl_stat = box.stat.vinyl()
-    utils.set_gauge('vinyl_disk_data_size', 'Amount of data stored in files', vinyl_stat.disk.data)
-    utils.set_gauge('vinyl_disk_index_size', 'Amount of index stored in files', vinyl_stat.disk.index)
+    collectors_list.vinyl_disk_data_size =
+        utils.set_gauge('vinyl_disk_data_size', 'Amount of data stored in files', vinyl_stat.disk.data)
+    collectors_list.vinyl_disk_index_size =
+        utils.set_gauge('vinyl_disk_index_size', 'Amount of index stored in files', vinyl_stat.disk.index)
 
-    utils.set_gauge('vinyl_regulator_dump_bandwidth', 'Estimated average rate at which dumps are done',
+    collectors_list.vinyl_regulator_dump_bandwidth =
+        utils.set_gauge('vinyl_regulator_dump_bandwidth', 'Estimated average rate at which dumps are done',
         vinyl_stat.regulator.dump_bandwidth)
-    utils.set_gauge('vinyl_regulator_write_rate', 'Average rate at which recent writes to disk are done',
+    collectors_list.vinyl_regulator_write_rate =
+        utils.set_gauge('vinyl_regulator_write_rate', 'Average rate at which recent writes to disk are done',
         vinyl_stat.regulator.write_rate)
-    utils.set_gauge('vinyl_regulator_rate_limit', 'Write rate limit', vinyl_stat.regulator.rate_limit)
-    utils.set_gauge('vinyl_regulator_dump_watermark', 'Point when dumping must occur',
+    collectors_list.vinyl_regulator_rate_limit =
+        utils.set_gauge('vinyl_regulator_rate_limit', 'Write rate limit', vinyl_stat.regulator.rate_limit)
+    collectors_list.vinyl_regulator_dump_watermark =
+        utils.set_gauge('vinyl_regulator_dump_watermark', 'Point when dumping must occur',
         vinyl_stat.regulator.dump_watermark)
 
-    utils.set_gauge('vinyl_tx_conflict', 'Count of transaction conflicts', vinyl_stat.tx.conflict)
-    utils.set_gauge('vinyl_tx_commit', 'Count of commits', vinyl_stat.tx.commit)
-    utils.set_gauge('vinyl_tx_rollback', 'Count of rollbacks', vinyl_stat.tx.rollback)
-    utils.set_gauge('vinyl_tx_read_views', 'Count of open read views', vinyl_stat.tx.read_views)
+    collectors_list.vinyl_tx_conflict =
+        utils.set_gauge('vinyl_tx_conflict', 'Count of transaction conflicts', vinyl_stat.tx.conflict)
+    collectors_list.vinyl_tx_commit =
+        utils.set_gauge('vinyl_tx_commit', 'Count of commits', vinyl_stat.tx.commit)
+    collectors_list.vinyl_tx_rollback =
+        utils.set_gauge('vinyl_tx_rollback', 'Count of rollbacks', vinyl_stat.tx.rollback)
+    collectors_list.vinyl_tx_read_views =
+        utils.set_gauge('vinyl_tx_read_views', 'Count of open read views', vinyl_stat.tx.read_views)
 
-    utils.set_gauge('vinyl_memory_tuple_cache', 'Number of bytes that are being used for tuple',
+    collectors_list.vinyl_memory_tuple_cache =
+        utils.set_gauge('vinyl_memory_tuple_cache', 'Number of bytes that are being used for tuple',
         vinyl_stat.memory.tuple_cache)
-    utils.set_gauge('vinyl_memory_level0', 'Size of in-memory storage of an LSM tree', vinyl_stat.memory.level0)
-    utils.set_gauge('vinyl_memory_page_index', 'Size of page indexes', vinyl_stat.memory.page_index)
-    utils.set_gauge('vinyl_memory_bloom_filter', 'Size of bloom filter', vinyl_stat.memory.bloom_filter)
+    collectors_list.vinyl_memory_level0 =
+        utils.set_gauge('vinyl_memory_level0', 'Size of in-memory storage of an LSM tree', vinyl_stat.memory.level0)
+    collectors_list.vinyl_memory_page_index =
+        utils.set_gauge('vinyl_memory_page_index', 'Size of page indexes', vinyl_stat.memory.page_index)
+    collectors_list.vinyl_memory_bloom_filter =
+        utils.set_gauge('vinyl_memory_bloom_filter', 'Size of bloom filter', vinyl_stat.memory.bloom_filter)
 
-    utils.set_gauge('vinyl_scheduler_tasks', 'Vinyl tasks count', vinyl_stat.scheduler.tasks_inprogress,
+    collectors_list.vinyl_scheduler_tasks =
+        utils.set_gauge('vinyl_scheduler_tasks', 'Vinyl tasks count', vinyl_stat.scheduler.tasks_inprogress,
         {status = 'inprogress'})
-    utils.set_gauge('vinyl_scheduler_tasks', 'Vinyl tasks count', vinyl_stat.scheduler.tasks_completed,
+    collectors_list.vinyl_scheduler_tasks =
+        utils.set_gauge('vinyl_scheduler_tasks', 'Vinyl tasks count', vinyl_stat.scheduler.tasks_completed,
         {status = 'completed'})
-    utils.set_gauge('vinyl_scheduler_tasks', 'Vinyl tasks count', vinyl_stat.scheduler.tasks_failed,
+    collectors_list.vinyl_scheduler_tasks =
+        utils.set_gauge('vinyl_scheduler_tasks', 'Vinyl tasks count', vinyl_stat.scheduler.tasks_failed,
         {status = 'failed'})
 
-    utils.set_gauge('vinyl_scheduler_dump_time', 'Total time spent by all worker threads performing dump',
+    collectors_list.vinyl_scheduler_dump_time =
+        utils.set_gauge('vinyl_scheduler_dump_time', 'Total time spent by all worker threads performing dump',
         vinyl_stat.scheduler.dump_time)
-    utils.set_gauge('vinyl_scheduler_dump_count', 'The count of completed dumps', vinyl_stat.scheduler.dump_count)
+    collectors_list.vinyl_scheduler_dump_count =
+        utils.set_gauge('vinyl_scheduler_dump_count', 'The count of completed dumps', vinyl_stat.scheduler.dump_count)
 end
 
 return {
-    update = update
+    update = update,
+    list = collectors_list,
 }

--- a/metrics/utils.lua
+++ b/metrics/utils.lua
@@ -9,6 +9,7 @@ end
 local function set_gauge(name, description, value, labels)
     local gauge = metrics.gauge(prefix_name(name), description)
     gauge:set(value, labels or {})
+    return gauge
 end
 
 local function box_is_configured()

--- a/test/integration/cartridge_role_test.lua
+++ b/test/integration/cartridge_role_test.lua
@@ -671,66 +671,6 @@ g.test_invalig_global_labels_names = function()
     }, 'label name is not allowed to be "zone" or "alias"')
 end
 
-g.test_include_metrics = function()
-    local server = g.cluster.main_server
-    server:upload_config({
-        metrics = {
-            export = {
-                {
-                    path = '/metrics',
-                    format = 'json'
-                },
-            },
-            include = {
-                'vinyl', 'luajit',
-            }
-        }
-    })
-
-    local resp = server:http_request('get', '/metrics', {raise = false})
-    t.assert_equals(resp.status, 200)
-
-    local metrics_cnt = #resp.json
-    local vinyl_metrics = fun.iter(resp.json):filter(function(x)
-        return x.metric_name:find('tnt_vinyl')
-    end):length()
-    local lj_metrics = fun.iter(resp.json):filter(function(x)
-        return x.metric_name:find('lj_')
-    end):length()
-    t.assert_equals(metrics_cnt, vinyl_metrics + lj_metrics)
-end
-
-g.test_exclude_metrics = function()
-    local server = g.cluster.main_server
-    server:upload_config({
-        metrics = {
-            export = {
-                {
-                    path = '/metrics',
-                    format = 'json'
-                },
-            },
-            exclude = {
-                'vinyl', 'luajit',
-            }
-        }
-    })
-
-    local resp = server:http_request('get', '/metrics', {raise = false})
-    t.assert_equals(resp.status, 200)
-
-    local metrics_cnt = #resp.json
-    t.assert(metrics_cnt >= 0)
-    local vinyl_metrics = fun.iter(resp.json):filter(function(x)
-        return x.metric_name:find('tnt_vinyl')
-    end):length()
-    t.assert_equals(vinyl_metrics, 0)
-    local lj_metrics = fun.iter(resp.json):filter(function(x)
-        return x.metric_name:find('lj_')
-    end):length()
-    t.assert_equals(lj_metrics, 0)
-end
-
 g.test_exclude_after_include = function()
     local server = g.cluster.main_server
     server:upload_config({

--- a/test/integration/cartridge_role_test.lua
+++ b/test/integration/cartridge_role_test.lua
@@ -697,10 +697,7 @@ g.test_include_metrics = function()
     local lj_metrics = fun.iter(resp.json):filter(function(x)
         return x.metric_name:find('lj_')
     end):length()
-    local cartridge_metrics = fun.iter(resp.json):filter(function(x)
-        return x.metric_name:find('tnt_cartridge_issues') or x.metric_name:find('tnt_clock_delta')
-    end):length()
-    t.assert_equals(metrics_cnt, vinyl_metrics + lj_metrics + cartridge_metrics)
+    t.assert_equals(metrics_cnt, vinyl_metrics + lj_metrics)
 end
 
 g.test_exclude_metrics = function()
@@ -723,12 +720,69 @@ g.test_exclude_metrics = function()
     t.assert_equals(resp.status, 200)
 
     local metrics_cnt = #resp.json
-    t.assert(metrics_cnt > 0)
+    t.assert_gt(metrics_cnt, 0)
     local vinyl_metrics = fun.iter(resp.json):filter(function(x)
         return x.metric_name:find('tnt_vinyl')
     end):length()
     t.assert_equals(vinyl_metrics, 0)
     local lj_metrics = fun.iter(resp.json):filter(function(x)
+        return x.metric_name:find('lj_')
+    end):length()
+    t.assert_equals(lj_metrics, 0)
+end
+
+g.test_exclude_after_include = function()
+    local server = g.cluster.main_server
+    server:upload_config({
+        metrics = {
+            export = {
+                {
+                    path = '/metrics',
+                    format = 'json'
+                },
+            },
+            include = {
+                'vinyl', 'luajit',
+            }
+        }
+    })
+
+    local resp = server:http_request('get', '/metrics', {raise = false})
+    t.assert_equals(resp.status, 200)
+
+    local metrics_cnt = #resp.json
+    local vinyl_metrics = fun.iter(resp.json):filter(function(x)
+        return x.metric_name:find('tnt_vinyl')
+    end):length()
+    local lj_metrics = fun.iter(resp.json):filter(function(x)
+        return x.metric_name:find('lj_')
+    end):length()
+    t.assert_equals(metrics_cnt, vinyl_metrics + lj_metrics)
+
+    server:upload_config({
+        metrics = {
+            export = {
+                {
+                    path = '/metrics',
+                    format = 'json'
+                },
+            },
+            exclude = {
+                'vinyl', 'luajit',
+            }
+        }
+    })
+
+    resp = server:http_request('get', '/metrics', {raise = false})
+    t.assert_equals(resp.status, 200)
+
+    metrics_cnt = #resp.json
+    t.assert_gt(metrics_cnt, 0)
+    vinyl_metrics = fun.iter(resp.json):filter(function(x)
+        return x.metric_name:find('tnt_vinyl')
+    end):length()
+    t.assert_equals(vinyl_metrics, 0)
+    lj_metrics = fun.iter(resp.json):filter(function(x)
         return x.metric_name:find('lj_')
     end):length()
     t.assert_equals(lj_metrics, 0)
@@ -746,5 +800,5 @@ g.test_exclude_and_include_metrics_raises_error = function()
             include = { 'vinyl' },
             exclude = { 'luajit' },
         }
-    }, "don't use exclude and include section together")
+    }, "don't use exclude and include sections together")
 end

--- a/test/integration/cartridge_role_test.lua
+++ b/test/integration/cartridge_role_test.lua
@@ -720,7 +720,7 @@ g.test_exclude_metrics = function()
     t.assert_equals(resp.status, 200)
 
     local metrics_cnt = #resp.json
-    t.assert_gt(metrics_cnt, 0)
+    t.assert(metrics_cnt >= 0)
     local vinyl_metrics = fun.iter(resp.json):filter(function(x)
         return x.metric_name:find('tnt_vinyl')
     end):length()
@@ -777,7 +777,7 @@ g.test_exclude_after_include = function()
     t.assert_equals(resp.status, 200)
 
     metrics_cnt = #resp.json
-    t.assert_gt(metrics_cnt, 0)
+    t.assert(metrics_cnt >= 0)
     vinyl_metrics = fun.iter(resp.json):filter(function(x)
         return x.metric_name:find('tnt_vinyl')
     end):length()

--- a/test/integration/hotreload_test.lua
+++ b/test/integration/hotreload_test.lua
@@ -25,8 +25,7 @@ g.test_reload = function()
     )
     http_requests_latency:observe(10)
 
-    require('metrics.default_metrics.tarantool').enable()
-    require('metrics.tarantool.luajit').enable()
+    metrics.enable_default_metrics()
 
     for k, _ in pairs(package.loaded) do
         if k:find('metrics') ~= nil then
@@ -36,7 +35,5 @@ g.test_reload = function()
 
     metrics = require('metrics')
 
-    require('metrics.default_metrics.tarantool').enable()
-    require('metrics.tarantool.luajit').enable()
     metrics.enable_default_metrics()
 end


### PR DESCRIPTION
I've added `include` and `exclude` sections to config to configure which metrics are exported.

When you add `include` section, only metrics from this section are exported:

```yml
metrics:
  export: ...
  # export only vinyl, luajit and memory metrics:
  include:
  - vinyl
  - luajit
  - memory
```

When you add `exclude` section, metrics from this section are removed from default metrics list:

```yml
metrics:
  export: ...
  # export all metrics except vinyl, luajit and memory:
  exclude:
  - vinyl
  - luajit
  - memory
```

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rst)

Close #222
