### PR TITLE
Fix cartridge issues metric call before cartridge.cfg()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Throw an error when http_middelware is processing a wrong handler [#199](https://github.com/tarantool/metrics/issues/199)
+- cartridge issues metric fails before cartridge.cfg() call [#298](https://github.com/tarantool/metrics/issues/298)
 
 ## [0.10.0] - 2021-08-03
 ### Changed

--- a/metrics/cartridge.lua
+++ b/metrics/cartridge.lua
@@ -2,7 +2,6 @@ local metrics = require('metrics')
 
 local cartridge_metrics = {
     require('metrics.cartridge.issues'),
-    require('metrics.tarantool.clock'),
 }
 
 local function enable()

--- a/metrics/cartridge/issues.lua
+++ b/metrics/cartridge/issues.lua
@@ -3,14 +3,18 @@ local fun = require('fun')
 
 local collectors_list = {}
 
-local function update_info_metrics()
+local function update()
     local list_on_instance = rawget(_G, '__cartridge_issues_list_on_instance')
 
     if not list_on_instance then
         return
     end
 
-    local issues = list_on_instance()
+    local ok, issues = pcall(list_on_instance)
+
+    if not ok then
+        return
+    end
 
     local levels = { 'warning', 'critical' }
 
@@ -22,6 +26,6 @@ local function update_info_metrics()
 end
 
 return {
-    update = update_info_metrics,
+    update = update,
     list = collectors_list,
 }

--- a/test/unit/cartridge_issues_test.lua
+++ b/test/unit/cartridge_issues_test.lua
@@ -1,0 +1,15 @@
+local helpers = require('test.helper')
+
+local t = require('luatest')
+local g = t.group()
+
+g.before_all = function()
+    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
+end
+
+g.test_cartridge_issues_before_cartridge_cfg = function()
+    require('cartridge.issues')
+    local issues = require('metrics.cartridge.issues')
+    local ok, error = pcall(issues.update)
+    t.assert(ok, error)
+end

--- a/test/unit/cartridge_issues_test.lua
+++ b/test/unit/cartridge_issues_test.lua
@@ -5,6 +5,7 @@ local g = t.group()
 
 g.before_all = function()
     t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
+    helpers.skip_cartridge_version_less('2.0.2')
 end
 
 g.test_cartridge_issues_before_cartridge_cfg = function()


### PR DESCRIPTION
Before `cartridge.cfg()` call `list_on_instance` throw an error. I pcall it.

I didn't forget about

- [x] Tests
- [x] Changelog

Close #298 
