### PR TITLE
Set quantile value to NAN if there are no samples provided for an age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Throw an error when http_middelware is processing a wrong handler [#199](https://github.com/tarantool/metrics/issues/199)
 - cartridge issues metric fails before cartridge.cfg() call [#298](https://github.com/tarantool/metrics/issues/298)
 
+### Changed
+- quantile metric is NAN if no samples provided for an age [#303](https://github.com/tarantool/metrics/issues/303)
+
 ## [0.10.0] - 2021-08-03
 ### Changed
 - metrics registry refactoring to search with `O(1)` [#188](https://github.com/tarantool/metrics/issues/188)

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -257,7 +257,7 @@ Summary
         see :ref:`counter_obj:collect() <counter-collect>`.
         If ``max_age_time`` and ``age_buckets_count`` are set, quantile observations
         will be collect only from the head bucket in sliding window and not from every
-        bucket.
+        bucket. If there was no observations returns NaN in values.
 
     ..  method:: remove(label_pairs)
 

--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -31,6 +31,7 @@ build = {
         ['metrics.collectors.counter']      = 'metrics/collectors/counter.lua',
         ['metrics.collectors.gauge']        = 'metrics/collectors/gauge.lua',
         ['metrics.collectors.histogram']    = 'metrics/collectors/histogram.lua',
+        ['metrics.const']                   = 'metrics/const.lua',
         ['metrics.plugins.graphite']        = 'metrics/plugins/graphite.lua',
         ['metrics.plugins.prometheus']      = 'metrics/plugins/prometheus.lua',
         ['metrics.plugins.json']            = 'metrics/plugins/json.lua',

--- a/metrics/const.lua
+++ b/metrics/const.lua
@@ -1,0 +1,4 @@
+return {
+    INF = math.huge,
+    NAN = math.huge * 0,
+}

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -3,6 +3,7 @@
 local checks = require('checks')
 local log = require('log')
 
+local Const = require('metrics.const')
 local Registry = require('metrics.registry')
 
 local Counter = require('metrics.collectors.counter')
@@ -108,8 +109,8 @@ return {
     histogram = histogram,
     summary = summary,
 
-    INF = math.huge,
-    NAN = math.huge * 0,
+    INF = Const.INF,
+    NAN = Const.NAN,
 
     clear = clear,
     collectors = collectors,

--- a/metrics/quantile.lua
+++ b/metrics/quantile.lua
@@ -1,4 +1,5 @@
 local ffi = require('ffi')
+local const = require('metrics.const')
 
 local quantile = {}
 
@@ -270,6 +271,10 @@ function quantile.Query(stream_obj, q)
 		-- Fast path when there hasn't been enough data for a flush;
 		-- this also yields better accuracy for small sets of data.
 		local l = stream_obj.b_len
+		if l == 0 then
+			return const.NAN
+		end
+
 		local i = math.modf(l * q)
 		stream_obj:maybe_sort()
 		return stream_obj.b[i]

--- a/metrics/quantile.lua
+++ b/metrics/quantile.lua
@@ -271,6 +271,8 @@ function quantile.Query(stream_obj, q)
 		-- Fast path when there hasn't been enough data for a flush;
 		-- this also yields better accuracy for small sets of data.
 		local l = stream_obj.b_len
+
+		-- if buffer is empty and wasn't flushed yet then quantile value is NaN
 		if l == 0 then
 			return const.NAN
 		end

--- a/test/quantile_test.lua
+++ b/test/quantile_test.lua
@@ -175,7 +175,7 @@ g.test_quantile_insert_works_after_reset = function()
     t.assert_not_equals(res, math.huge)
 end
 
-g.test_quantile_full_buffer = function()
+g.test_quantile_values_present_after_buffer_flush = function()
     local Quantile = quantile.NewTargeted({[0.5]=0.01, [0.9]=0.01, [0.99]=0.01}, 10)
 
     for _ = 1, 10 do

--- a/test/quantile_test.lua
+++ b/test/quantile_test.lua
@@ -146,7 +146,7 @@ g.test_query_on_empty_quantile = function()
 
     local res = quantile.Query(emptyQuantile, 0.99)
 
-    t.assert_equals(res, math.huge)
+    t.assert_nan(res)
 end
 
 g.test_reset = function()
@@ -156,12 +156,12 @@ g.test_reset = function()
     end
 
     local res = quantile.Query(Quantile, 0.99)
-    t.assert_not_equals(res, math.huge)
+    t.assert_not_nan(res)
 
     quantile.Reset(Quantile)
 
     res = quantile.Query(Quantile, 0.99)
-    t.assert_equals(res, math.huge)
+    t.assert_nan(res)
 end
 
 g.test_quantile_insert_works_after_reset = function()

--- a/test/quantile_test.lua
+++ b/test/quantile_test.lua
@@ -174,3 +174,17 @@ g.test_quantile_insert_works_after_reset = function()
     local res = quantile.Query(Quantile, 0.5)
     t.assert_not_equals(res, math.huge)
 end
+
+g.test_quantile_full_buffer = function()
+    local Quantile = quantile.NewTargeted({[0.5]=0.01, [0.9]=0.01, [0.99]=0.01}, 10)
+
+    for _ = 1, 10 do
+        quantile.Insert(Quantile, math.random())
+    end
+
+    t.assert(Quantile:flushed())
+    -- buffer now is flushed
+
+    local res = quantile.Query(Quantile, 0.5)
+    t.assert_not_nan(res)
+end


### PR DESCRIPTION
Closes #303

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rst)
- [x] Rockspec and rpm spec

Set quantile value to NAN if there are no samples provided for an age.

Golang summary collector ([link](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#Summary) provided by Prometheus doc) uses NaN to set undefined quantile values. The decision was inpired by Golang solution.
