### PR TITLE
reduce gc pressure

### DIFF
--- a/metrics/http_middleware.lua
+++ b/metrics/http_middleware.lua
@@ -70,7 +70,7 @@ end
 -- @string route.method
 -- ... arguments for pcall to instrument
 -- @return value from observable function
-function export.observe(collector, route, ...)
+function export.observe(collector, route, handler, ...)
     return collector:observe_latency(function(ok, result)
         if type(result) ~= 'table' then
             error(('incorrect http handler for %s %s: expecting return response object'):
@@ -81,7 +81,7 @@ function export.observe(collector, route, ...)
             method = route.method,
             status = (not ok and 500) or result.status or 200,
         }
-    end, ...)
+    end, handler, ...)
 end
 
 --- Apply instrumentation middleware for http request handler


### PR DESCRIPTION
Metrics mustn't harm application performance. However currently
it's not so. We have a lot of closure creations on hot paths.
This patch doesn't solve an issue completely (see
observers source code) but reduces GC pressure a bit.

