### PR TITLE
ci: add reusable testing workflow

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -1,0 +1,31 @@
+name: Reusable Test
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: 'The name of the tarantool build artifact'
+        default: ubuntu-focal
+        required: false
+        type: string
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Clone the metrics module'
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository_owner }}/metrics
+
+      - name: 'Download the tarantool build artifact'
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ inputs.artifact_name }}
+
+      - name: 'Install tarantool'
+        # Now we're lucky: all dependencies are already installed. Check package
+        # dependencies when migrating to other OS version.
+        run: sudo dpkg -i tarantool*.deb
+
+      - run: make test

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint: .rocks
 
 .PHONY: test
 test: .rocks
-	.rocks/bin/luatest
+	.rocks/bin/luatest -v
 
 .PHONY: test_with_coverage_report
 test_with_coverage_report: .rocks


### PR DESCRIPTION
The idea of this workflow is to be a part of the 'integration.yml'
workflow from the tarantool repo to verify the integration of the
metrics module with an arbitrary tarantool version.

This workflow is not triggered on a push to the repo and cannot be run
manually since it has only the 'workflow_call' trigger. This workflow
will be included in the tarantool development cycle and called by the
'integration.yml' workflow from the tarantool project on a push to the
master and release branches for verifying integration of tarantool with
metrics.

Part of tarantool/tarantool#6526
Part of tarantool/tarantool#5265
Part of tarantool/tarantool#6056