### PR TITLE
ci: fix http dependency in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ rpm:
 	tarantoolctl rocks install luacov 0.13.0
 	tarantoolctl rocks install luacheck 0.26.0
 	if [ -z $(CARTRIDGE_VERSION) ]; then \
-		tarantoolctl rocks install http 2.1.0; \
+		tarantoolctl rocks install http-v2-legacy 2.1.0; \
 	else \
 		tarantoolctl rocks install cartridge $(CARTRIDGE_VERSION); \
 	fi


### PR DESCRIPTION
At this moment http dependency in tests is broken since we are trying
to install the `http 2.1.0` lua rock. Now this rock is not available
anymore due to tarantool/http#142 and that is the reason for test
failures with the following error:

    http not found for Lua 5.1.
    Error: No results matching query were found for Lua 5.1.
    Checking if available for other Lua versions...
    make: *** [Makefile:10: .rocks] Error 1
    Checking for Lua 5.2...
    Checking for Lua 5.3...
    Checking for Lua 5.4...
    Error: Process completed with exit code 2.

Now http v2 is available under the `http-v2-legacy` lua rock and this
patch switches the use of `http 2.1.0` to `http-v2-legacy 2.1.0`.

Manual [test run](https://github.com/tarantool/metrics/actions/runs/1399360375) with `http-v2-legacy 2.1.0`.
