### PR TITLE
Update url in rockspec

### DIFF
--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -2,7 +2,7 @@ package = 'metrics'
 version = 'scm-1'
 
 source  = {
-    url    = 'git://github.com/tarantool/metrics.git',
+    url    = 'git+https://github.com/tarantool/metrics.git',
     branch = 'master'
 }
 


### PR DESCRIPTION
Since GitHub is improving git protocol security, old links to rockspecs will be unavailable. 
See https://github.blog/2021-09-01-improving-git-protocol-security-github/