### PR TITLE
Fix table formatting

### DIFF
--- a/doc/monitoring/metrics_reference.rst
+++ b/doc/monitoring/metrics_reference.rst
@@ -188,8 +188,8 @@ Received bytes:
         :widths: 25 75
         :header-rows: 0
 
-    *   -   ``tnt_net_received_total``
-        -   Bytes received by the instance since start time
+        *   -   ``tnt_net_received_total``
+            -   Bytes received by the instance since start time
 
 Connections:
 


### PR DESCRIPTION
A table was displayed with a bug because of a formatting error. This fixes it.
