### PR TITLE
Update replicas.lua

### DIFF
--- a/metrics/tarantool/replicas.lua
+++ b/metrics/tarantool/replicas.lua
@@ -10,7 +10,7 @@ local function update_replicas_metrics()
     local current_box_info = box.info()
 
     if box.cfg.read_only then
-        for k, v in ipairs(current_box_info.vclock) do
+        for k, v in pairs(current_box_info.vclock) do
             local replication_info = current_box_info.replication[k]
             if replication_info then
                 local lsn = replication_info.lsn
@@ -22,7 +22,7 @@ local function update_replicas_metrics()
             end
         end
     else
-        for k, v in ipairs(current_box_info.replication) do
+        for k, v in pairs(current_box_info.replication) do
             if v.downstream ~= nil and v.downstream.vclock ~= nil then
                 local lsn = v.downstream.vclock[current_box_info.id]
                 if lsn ~= nil and current_box_info.lsn ~= nil then


### PR DESCRIPTION
> Всем привет. А подскажите, почему тарантул может не отдавай метрику tnt_replication_lag, версия тарантула 2.8.3-0-g01023dbc2, metrics устанавливали через rocks

> как-будто не итерируется по box.info().replication