### PR TITLE
Update info.lua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't reset collectors when Cartridge roles hot reload
+- `pairs` instead of `ipairs` in iterations over replication info
 
 ### Changed
 

--- a/metrics/tarantool/info.lua
+++ b/metrics/tarantool/info.lua
@@ -17,11 +17,11 @@ local function update_info_metrics()
     collectors_list.info_lsn = utils.set_gauge('info_lsn', 'Tarantool lsn', info.lsn)
     collectors_list.info_uptime = utils.set_gauge('info_uptime', 'Tarantool uptime', info.uptime)
 
-    for k, v in ipairs(info.vclock) do
+    for k, v in pairs(info.vclock) do
         collectors_list.info_vclock = utils.set_gauge('info_vclock', 'VClock', v, {id = k})
     end
 
-    for k, v in ipairs(info.replication) do
+    for k, v in pairs(info.replication) do
         if v.upstream ~= nil then
             local metric_name_old = 'replication_' .. k .. '_lag'
             collectors_list[metric_name_old] =


### PR DESCRIPTION
> Всем привет. А подскажите, почему тарантул может не отдавай метрику tnt_replication_lag, версия тарантула 2.8.3-0-g01023dbc2, metrics устанавливали через rocks
> как-будто не итерируется по box.info().replication