### PR TITLE
Skip backtraces for fiber.info calls

### DIFF
--- a/metrics/tarantool/fibers.lua
+++ b/metrics/tarantool/fibers.lua
@@ -4,7 +4,7 @@ local utils = require('metrics.utils')
 local collectors_list = {}
 
 local function update_fibers_metrics()
-    local fibers_info = fiber.info()
+    local fibers_info = fiber.info({backtrace = false})
     local fibers = 0
     local csws = 0
     local falloc = 0


### PR DESCRIPTION
This option was introduced but not documented.
See https://github.com/tarantool/tarantool/commit/b18dd47f50e817be5ef91013c5514fd6226d836d 
Let's skip backtraces because we actually don't even use it.
