### PR TITLE
Describe tnt_runtime_tuple metric

### DIFF
--- a/doc/monitoring/metrics_reference.rst
+++ b/doc/monitoring/metrics_reference.rst
@@ -374,6 +374,8 @@ Runtime
             -   Lua garbage collector size in bytes
         *   -   ``tnt_runtime_used``
             -   Number of bytes used for the Lua runtime
+        *   -   ``tnt_runtime_tuple``
+            -   Number of bytes used for the tuples (except tuples owned by memtx and vinyl)
 
 ..  _metrics-reference-cartridge:
 


### PR DESCRIPTION
`tnt_runtime_tuple` is added automatically in Tarantool >= 2.10

I didn't forget about

- [x] Documentation (README and rst)

Part of #360 
