### PR TITLE
Add tnt_cartridge_failover_trigger metric

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
           - "2.6"
           - "2.7"
           - "2.8"
-        cartridge: [ "", "1.2.0", "2.1.2", "2.4.0", "2.5.1", "2.6.0", "2.7.4" ]
+        cartridge: [ "", "1.2.0", "2.1.2", "2.4.0", "2.5.1", "2.6.0", "2.7.5" ]
         include:
           - tarantool: "2.x-latest"
-            cartridge: "2.7.4"
+            cartridge: "2.7.5"
           - tarantool: "2.x-latest"
             cartridge: ""
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `tnt_cartridge_cluster_issues` metric
+- `tnt_cartridge_failover_trigger` metric
 
 ### Deprecated
 

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -322,7 +322,7 @@ Metrics functions
     *   ``vinyl``
     *   ``luajit``
     *   ``cartridge_issues``
-    *   ``cartridge_cluster_issues``
+    *   ``cartridge_failover``
     *   ``clock``
     *   ``event_loop``
 

--- a/doc/monitoring/metrics_reference.rst
+++ b/doc/monitoring/metrics_reference.rst
@@ -408,8 +408,11 @@ Cartridge
                 This metric always has the label ``{delta="..."}``,
                 which has the following possible values:
 
-                *   ``max`` -- difference with the fastest clock (always positive)
+                *   ``max`` -- difference with the fastest clock (always positive),
                 *   ``min`` -- difference with the slowest clock (always negative).
+
+        *   -   ``tnt_cartridge_failover_trigger``
+            -   Count of failover triggers in cluster.
 
 ..  _metrics-reference-luajit:
 

--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -49,6 +49,7 @@ build = {
         ['metrics.tarantool.cpu']           = 'metrics/tarantool/cpu.lua',
         ['metrics.tarantool.event_loop']    = 'metrics/tarantool/event_loop.lua',
         ['metrics.cartridge.issues']        = 'metrics/cartridge/issues.lua',
+        ['metrics.cartridge.failover']      = 'metrics/cartridge/failover.lua',
         ['metrics.tarantool.clock']         = 'metrics/tarantool/clock.lua',
         ['metrics.psutils.cpu']             = 'metrics/psutils/cpu.lua',
         ['metrics.psutils.psutils_linux']   = 'metrics/psutils/psutils_linux.lua',

--- a/metrics/cartridge/failover.lua
+++ b/metrics/cartridge/failover.lua
@@ -1,0 +1,29 @@
+local is_cartridge = pcall(require, 'cartridge')
+
+if not is_cartridge then
+    return {
+        update = function() end,
+        list = {},
+    }
+end
+
+local utils = require('metrics.utils')
+local collectors_list = {}
+local vars = require('cartridge.vars').new('cartridge.failover')
+
+local function update()
+    local trigger_cnt = vars.failover_trigger_cnt
+    if trigger_cnt ~= nil then
+        collectors_list.trigger_cnt =
+            utils.set_gauge(
+                'cartridge_failover_trigger',
+                'Count of Cartridge Failover triggers',
+                trigger_cnt
+            )
+    end
+end
+
+return {
+    update = update,
+    list = collectors_list,
+}

--- a/metrics/cartridge/failover.lua
+++ b/metrics/cartridge/failover.lua
@@ -15,7 +15,7 @@ local function update()
     local trigger_cnt = vars.failover_trigger_cnt
     if trigger_cnt ~= nil then
         collectors_list.trigger_cnt =
-            utils.set_gauge(
+            utils.set_counter(
                 'cartridge_failover_trigger',
                 'Count of Cartridge Failover triggers',
                 trigger_cnt

--- a/metrics/tarantool.lua
+++ b/metrics/tarantool.lua
@@ -15,6 +15,7 @@ local default_metrics = {
     vinyl               = require('metrics.tarantool.vinyl'),
     luajit              = require('metrics.tarantool.luajit'),
     cartridge_issues    = require('metrics.cartridge.issues'),
+    cartridge_failover  = require('metrics.cartridge.failover'),
     clock               = require('metrics.tarantool.clock'),
     event_loop          = require('metrics.tarantool.event_loop'),
 }

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -41,6 +41,22 @@ function helpers.init_cluster(env)
         env = env,
     })
     cluster:start()
+    cluster:wait_until_healthy()
+    cluster.main_server:graphql({
+        query = [[
+            mutation($mode: String) {
+                cluster {
+                    failover_params(
+                        mode: $mode
+                    ) {
+                        mode
+                    }
+                }
+            }
+        ]],
+        variables = { mode = 'eventual' },
+        raise = false,
+    })
     return cluster
 end
 

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -41,22 +41,6 @@ function helpers.init_cluster(env)
         env = env,
     })
     cluster:start()
-    cluster:wait_until_healthy()
-    cluster.main_server:graphql({
-        query = [[
-            mutation($mode: String) {
-                cluster {
-                    failover_params(
-                        mode: $mode
-                    ) {
-                        mode
-                    }
-                }
-            }
-        ]],
-        variables = { mode = 'eventual' },
-        raise = false,
-    })
     return cluster
 end
 

--- a/test/integration/cartridge_metrics_test.lua
+++ b/test/integration/cartridge_metrics_test.lua
@@ -113,3 +113,12 @@ g.test_read_only = function()
     read_only = utils.find_metric('tnt_read_only', resp.json)
     t.assert_equals(read_only[1].value, 1)
 end
+
+g.test_failover = function()
+    helpers.skip_cartridge_version_less('2.7.5')
+    local main_server = g.cluster:server('main')
+
+    local resp = main_server:http_request('get', '/metrics')
+    local failover_trigger_cnt = utils.find_metric('tnt_cartridge_failover_trigger', resp.json)
+    t.assert_equals(failover_trigger_cnt[1].value, 0)
+end

--- a/test/integration/cartridge_metrics_test.lua
+++ b/test/integration/cartridge_metrics_test.lua
@@ -116,6 +116,23 @@ end
 
 g.before_test('test_failover', function()
     helpers.skip_cartridge_version_less('2.7.5')
+    g.cluster:wait_until_healthy()
+    g.cluster.main_server:graphql({
+        query = [[
+            mutation($mode: String) {
+                cluster {
+                    failover_params(
+                        mode: $mode
+                    ) {
+                        mode
+                    }
+                }
+            }
+        ]],
+        variables = { mode = 'eventual' },
+        raise = false,
+    })
+    g.cluster:wait_until_healthy()
     local main_server = g.cluster:server('main')
     main_server:stop()
 end)

--- a/test/integration/cartridge_metrics_test.lua
+++ b/test/integration/cartridge_metrics_test.lua
@@ -114,7 +114,7 @@ g.test_read_only = function()
     t.assert_equals(read_only[1].value, 1)
 end
 
-g.before_test('test_failover', function()
+g.test_failover = function()
     helpers.skip_cartridge_version_less('2.7.5')
     g.cluster:wait_until_healthy()
     g.cluster.main_server:graphql({
@@ -133,20 +133,14 @@ g.before_test('test_failover', function()
         raise = false,
     })
     g.cluster:wait_until_healthy()
-    local main_server = g.cluster:server('main')
-    main_server:stop()
-end)
+    g.cluster.main_server:stop()
 
-g.test_failover = function()
     helpers.retrying({timeout = 30}, function()
         local resp = g.cluster:server('replica'):http_request('get', '/metrics')
         local failover_trigger_cnt = utils.find_metric('tnt_cartridge_failover_trigger', resp.json)
         t.assert_equals(failover_trigger_cnt[1].value, 1)
     end)
-end
 
-g.after_test('test_failover', function()
-    local main_server = g.cluster:server('main')
-    main_server:start()
+    g.cluster.main_server:start()
     g.cluster:wait_until_healthy()
-end)
+end

--- a/test/integration/cartridge_metrics_test.lua
+++ b/test/integration/cartridge_metrics_test.lua
@@ -116,21 +116,20 @@ end
 
 g.before_test('test_failover', function()
     helpers.skip_cartridge_version_less('2.7.5')
-    local replica_server = g.cluster:server('replica')
-    replica_server:stop()
+    local main_server = g.cluster:server('main')
+    main_server:stop()
 end)
 
 g.test_failover = function()
-    local main_server = g.cluster:server('main')
     helpers.retrying({timeout = 20}, function()
-        local resp = main_server:http_request('get', '/metrics')
+        local resp = g.cluster:server('replica'):http_request('get', '/metrics')
         local failover_trigger_cnt = utils.find_metric('tnt_cartridge_failover_trigger', resp.json)
         t.assert_equals(failover_trigger_cnt[1].value, 1)
     end)
 end
 
 g.after_test('test_failover', function()
-    local replica_server = g.cluster:server('replica')
-    replica_server:start()
+    local main_server = g.cluster:server('main')
+    main_server:start()
     g.cluster:wait_until_healthy()
 end)

--- a/test/integration/cartridge_metrics_test.lua
+++ b/test/integration/cartridge_metrics_test.lua
@@ -121,7 +121,7 @@ g.before_test('test_failover', function()
 end)
 
 g.test_failover = function()
-    helpers.retrying({timeout = 20}, function()
+    helpers.retrying({timeout = 30}, function()
         local resp = g.cluster:server('replica'):http_request('get', '/metrics')
         local failover_trigger_cnt = utils.find_metric('tnt_cartridge_failover_trigger', resp.json)
         t.assert_equals(failover_trigger_cnt[1].value, 1)


### PR DESCRIPTION
Since we've added failover trigger count to cartridge (https://github.com/tarantool/cartridge/pull/1806), we should add it to metrics.

I didn't forget about

- [x] Changelog
- [x] Documentation (README and rst)
- [x] Rockspec and rpm spec
