### PR TITLE
optimize utils.box_is_configured

### DIFF
--- a/metrics/utils.lua
+++ b/metrics/utils.lua
@@ -1,15 +1,16 @@
 local metrics = require('metrics')
 
 local TNT_PREFIX = 'tnt_'
+local utils = {}
 
-local function set_gauge(name, description, value, labels, prefix)
+function utils.set_gauge(name, description, value, labels, prefix)
     prefix = prefix or TNT_PREFIX
     local gauge = metrics.gauge(prefix .. name, description)
     gauge:set(value, labels or {})
     return gauge
 end
 
-local function set_counter(name, description, value, labels, prefix)
+function utils.set_counter(name, description, value, labels, prefix)
     prefix = prefix or TNT_PREFIX
     local counter = metrics.counter(prefix .. name, description)
     counter:reset(labels or {})
@@ -17,12 +18,12 @@ local function set_counter(name, description, value, labels, prefix)
     return counter
 end
 
-local function box_is_configured()
-    return type(box.cfg) ~= 'function'
+function utils.box_is_configured()
+    local is_configured = type(box.cfg) ~= 'function'
+    if is_configured then
+        utils.box_is_configured = function() return true end
+    end
+    return is_configured
 end
 
-return {
-    set_gauge = set_gauge,
-    set_counter = set_counter,
-    box_is_configured = box_is_configured,
-}
+return utils


### PR DESCRIPTION
There is no reason to check box.cfg type for each call. Once box
was configured it will return true. So let's just replace module
function with dummy implementation that will return always true
after it returned `true` once.

