### PR TITLE
doc: add alerting page from grafana-dashboard

### DIFF
--- a/doc/monitoring/index.rst
+++ b/doc/monitoring/index.rst
@@ -18,3 +18,4 @@ This chapter includes the following sections:
     api_reference
     plugins
     grafana_dashboard
+    alerting


### PR DESCRIPTION
Should be merged together with https://github.com/tarantool/grafana-dashboard/pull/177

See https://github.com/tarantool/grafana-dashboard/pull/177 for details.

I didn't forget about

- Tests (not needed)
- Changelog (not needed)
- [x] Documentation (rst)
- Documentation (README not needed)
- Rockspec and rpm spec (not needed)
