### PR TITLE
Use the same logic in is_healthy as member_is_healthy from cartridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `is_healthy` function to rely on membership state
+
 ## [0.15.1] - 2022-09-20
 ### Added
 

--- a/cartridge/health.lua
+++ b/cartridge/health.lua
@@ -1,13 +1,24 @@
 local membership = require('membership')
 local argparse = require('cartridge.argparse')
 
+-- Original private member_is_healthy function:
+-- https://github.com/tarantool/cartridge/blob/master/cartridge/rpc.lua
 local function is_healthy(_)
     local member = membership.myself()
     local parse = argparse.parse()
     local instance = parse.instance_name or parse.alias or 'instance'
-    if box.info.status and box.info.status == 'running' and member and
-        member.status and member.status == 'alive' and member.payload and
-        member.payload.state and member.payload.state == 'RolesConfigured' then
+    if (member ~= nil)
+        and (member.status == 'alive' or member.status == 'suspect')
+        and (
+            member.payload.state_prev == nil or -- for backward compatibility with old versions
+            member.payload.state_prev == 'RolesConfigured' or
+            member.payload.state_prev == 'ConfiguringRoles'
+        )
+        and (
+            member.payload.state == 'ConfiguringRoles' or
+            member.payload.state == 'RolesConfigured'
+        )
+    then
         return {body = instance .. ' is OK', status = 200}
     else
         return {body = instance .. ' is dead', status = 500}

--- a/cartridge/health.lua
+++ b/cartridge/health.lua
@@ -1,5 +1,5 @@
-local membership = require("membership")
-local argparse = require("cartridge.argparse")
+local membership = require('membership')
+local argparse = require('cartridge.argparse')
 
 -- Original private member_is_healthy function:
 -- https://github.com/tarantool/cartridge/blob/master/cartridge/rpc.lua

--- a/cartridge/health.lua
+++ b/cartridge/health.lua
@@ -1,5 +1,5 @@
-local membership = require('membership')
-local argparse = require('cartridge.argparse')
+local membership = require("membership")
+local argparse = require("cartridge.argparse")
 
 -- Original private member_is_healthy function:
 -- https://github.com/tarantool/cartridge/blob/master/cartridge/rpc.lua
@@ -7,7 +7,8 @@ local function is_healthy(_)
     local member = membership.myself()
     local parse = argparse.parse()
     local instance = parse.instance_name or parse.alias or 'instance'
-    if (member ~= nil)
+    if box.info.status and box.info.status == 'running'
+        and member ~= nil
         and (member.status == 'alive' or member.status == 'suspect')
         and (
             member.payload.state_prev == nil or -- for backward compatibility with old versions
@@ -19,9 +20,9 @@ local function is_healthy(_)
             member.payload.state == 'RolesConfigured'
         )
     then
-        return {body = instance .. ' is OK', status = 200}
+        return {body = instance .. " is OK", status = 200}
     else
-        return {body = instance .. ' is dead', status = 500}
+        return {body = instance .. " is dead", status = 500}
     end
 end
 

--- a/test/integration/cartridge_health_test.lua
+++ b/test/integration/cartridge_health_test.lua
@@ -1,96 +1,78 @@
-local fio = require('fio')
-local t = require('luatest')
+local fio = require("fio")
+local t = require("luatest")
 local g = t.group()
 
-local helpers = require('test.helper')
+local helpers = require("test.helper")
 
-g.before_all(function()
-    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
-    g.cluster = helpers.init_cluster()
-end)
+g.before_all(
+    function()
+        t.skip_if(type(helpers) ~= "table", "Skip cartridge test")
+        g.cluster = helpers.init_cluster()
+    end
+)
 
-g.after_all(function()
-    g.cluster:stop()
-    fio.rmtree(g.cluster.datadir)
-end)
+g.after_all(
+    function()
+        g.cluster:stop()
+        fio.rmtree(g.cluster.datadir)
+    end
+)
 
 g.test_cartridge_health_handler = function()
-    helpers.skip_cartridge_version_less('2.0.2')
+    helpers.skip_cartridge_version_less("2.0.2")
     helpers.upload_default_metrics_config(g.cluster)
-    local main_server = g.cluster:server('main')
-    local resp = main_server:http_request('get', '/health', {raise = false})
+    local main_server = g.cluster:server("main")
+    local resp = main_server:http_request("get", "/health", {raise = false})
     t.assert_equals(resp.status, 200)
 end
 
 g.test_cartridge_health_fail_handler = function()
-    helpers.skip_cartridge_version_less('2.0.2')
+    helpers.skip_cartridge_version_less("2.0.2")
     helpers.upload_default_metrics_config(g.cluster)
-    local main_server = g.cluster:server('main')
-    main_server.net_box:eval([[
+    local main_server = g.cluster:server("main")
+    main_server.net_box:eval(
+        [[
         _G.old_info = box.info
         box.info = {
             status = 'orphan',
         }
-    ]])
-    local resp = main_server:http_request('get', '/health', {raise = false})
+    ]]
+    )
+    local resp = main_server:http_request("get", "/health", {raise = false})
     t.assert_equals(resp.status, 500)
     main_server.net_box:eval([[
         box.info = _G.old_info
     ]])
 end
 
-g.test_cartridge_health_handler_state_1 = function()
-    helpers.skip_cartridge_version_less('2.0.2')
+g.test_cartridge_health_handler_member_state_configured_configuring = function()
+    helpers.skip_cartridge_version_less("2.0.2")
     helpers.upload_default_metrics_config(g.cluster)
-    local main_server = g.cluster:server('main')
-    main_server.net_box:eval([[
-        _G.old_info = box.info
-        box.info = {
-            status = 'alive',
-            state = 'RolesConfigured'
-        }
-    ]])
-    local resp = main_server:http_request('get', '/health', {raise = false})
+    local main_server = g.cluster:server("main")
+    main_server.net_box:eval(
+        [[
+        myself = require('membership').myself()
+
+        myself.payload.state='ConfiguringRoles'
+        myself.payload.state_prev='RolesConfigured'
+    ]]
+    )
+    local resp = main_server:http_request("get", "/health", {raise = false})
     t.assert_equals(resp.status, 200)
-    main_server.net_box:eval([[
-        box.info = _G.old_info
-    ]])
 end
 
-g.test_cartridge_health_handler_state_2 = function()
-    helpers.skip_cartridge_version_less('2.0.2')
+g.test_cartridge_health_handler_member_state_boxconfigured_configuring = function()
+    helpers.skip_cartridge_version_less("2.0.2")
     helpers.upload_default_metrics_config(g.cluster)
-    local main_server = g.cluster:server('main')
-    main_server.net_box:eval([[
-        _G.old_info = box.info
-        box.info = {
-            status = 'alive',
-            state = 'ConfiguringRoles',
-            state_prev = 'RolesConfigured'
-        }
-    ]])
-    local resp = main_server:http_request('get', '/health', {raise = false})
-    t.assert_equals(resp.status, 200)
-    main_server.net_box:eval([[
-        box.info = _G.old_info
-    ]])
-end
+    local main_server = g.cluster:server("main")
+    main_server.net_box:eval(
+        [[
+        myself = require('membership').myself()
 
-g.test_cartridge_health_fail_handler_state_1 = function()
-    helpers.skip_cartridge_version_less('2.0.2')
-    helpers.upload_default_metrics_config(g.cluster)
-    local main_server = g.cluster:server('main')
-    main_server.net_box:eval([[
-        _G.old_info = box.info
-        box.info = {
-            status = 'alive',
-            state = 'ConfiguringRoles',
-            state_prev = 'BoxConfigured'
-        }
-    ]])
-    local resp = main_server:http_request('get', '/health', {raise = false})
+        myself.payload.state='ConfiguringRoles'
+        myself.payload.state_prev='BoxConfigured'
+    ]]
+    )
+    local resp = main_server:http_request("get", "/health", {raise = false})
     t.assert_equals(resp.status, 500)
-    main_server.net_box:eval([[
-        box.info = _G.old_info
-    ]])
 end

--- a/test/integration/cartridge_health_test.lua
+++ b/test/integration/cartridge_health_test.lua
@@ -38,3 +38,59 @@ g.test_cartridge_health_fail_handler = function()
         box.info = _G.old_info
     ]])
 end
+
+g.test_cartridge_health_handler_state_1 = function()
+    helpers.skip_cartridge_version_less('2.0.2')
+    helpers.upload_default_metrics_config(g.cluster)
+    local main_server = g.cluster:server('main')
+    main_server.net_box:eval([[
+        _G.old_info = box.info
+        box.info = {
+            status = 'alive',
+            state = 'RolesConfigured'
+        }
+    ]])
+    local resp = main_server:http_request('get', '/health', {raise = false})
+    t.assert_equals(resp.status, 200)
+    main_server.net_box:eval([[
+        box.info = _G.old_info
+    ]])
+end
+
+g.test_cartridge_health_handler_state_2 = function()
+    helpers.skip_cartridge_version_less('2.0.2')
+    helpers.upload_default_metrics_config(g.cluster)
+    local main_server = g.cluster:server('main')
+    main_server.net_box:eval([[
+        _G.old_info = box.info
+        box.info = {
+            status = 'alive',
+            state = 'ConfiguringRoles',
+            state_prev = 'RolesConfigured'
+        }
+    ]])
+    local resp = main_server:http_request('get', '/health', {raise = false})
+    t.assert_equals(resp.status, 200)
+    main_server.net_box:eval([[
+        box.info = _G.old_info
+    ]])
+end
+
+g.test_cartridge_health_fail_handler_state_1 = function()
+    helpers.skip_cartridge_version_less('2.0.2')
+    helpers.upload_default_metrics_config(g.cluster)
+    local main_server = g.cluster:server('main')
+    main_server.net_box:eval([[
+        _G.old_info = box.info
+        box.info = {
+            status = 'alive',
+            state = 'ConfiguringRoles',
+            state_prev = 'BoxConfigured'
+        }
+    ]])
+    local resp = main_server:http_request('get', '/health', {raise = false})
+    t.assert_equals(resp.status, 500)
+    main_server.net_box:eval([[
+        box.info = _G.old_info
+    ]])
+end

--- a/test/integration/cartridge_health_test.lua
+++ b/test/integration/cartridge_health_test.lua
@@ -1,44 +1,38 @@
-local fio = require("fio")
-local t = require("luatest")
+local fio = require('fio')
+local t = require('luatest')
 local g = t.group()
 
-local helpers = require("test.helper")
+local helpers = require('test.helper')
 
-g.before_all(
-    function()
-        t.skip_if(type(helpers) ~= "table", "Skip cartridge test")
-        g.cluster = helpers.init_cluster()
-    end
-)
+g.before_all(function()
+    t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
+    g.cluster = helpers.init_cluster()
+end)
 
-g.after_all(
-    function()
-        g.cluster:stop()
-        fio.rmtree(g.cluster.datadir)
-    end
-)
+g.after_all(function()
+    g.cluster:stop()
+    fio.rmtree(g.cluster.datadir)
+end)
 
 g.test_cartridge_health_handler = function()
-    helpers.skip_cartridge_version_less("2.0.2")
+    helpers.skip_cartridge_version_less('2.0.2')
     helpers.upload_default_metrics_config(g.cluster)
-    local main_server = g.cluster:server("main")
-    local resp = main_server:http_request("get", "/health", {raise = false})
+    local main_server = g.cluster:server('main')
+    local resp = main_server:http_request('get', '/health', {raise = false})
     t.assert_equals(resp.status, 200)
 end
 
 g.test_cartridge_health_fail_handler = function()
-    helpers.skip_cartridge_version_less("2.0.2")
+    helpers.skip_cartridge_version_less('2.0.2')
     helpers.upload_default_metrics_config(g.cluster)
-    local main_server = g.cluster:server("main")
-    main_server.net_box:eval(
-        [[
+    local main_server = g.cluster:server('main')
+    main_server.net_box:eval([[
         _G.old_info = box.info
         box.info = {
             status = 'orphan',
         }
-    ]]
-    )
-    local resp = main_server:http_request("get", "/health", {raise = false})
+    ]])
+    local resp = main_server:http_request('get', '/health', {raise = false})
     t.assert_equals(resp.status, 500)
     main_server.net_box:eval([[
         box.info = _G.old_info

--- a/test/integration/cartridge_health_test.lua
+++ b/test/integration/cartridge_health_test.lua
@@ -39,30 +39,92 @@ g.test_cartridge_health_fail_handler = function()
     ]])
 end
 
-g.test_cartridge_health_handler_member_state_configured_configuring = function()
+g.test_cartridge_health_handler_member_alive_state_configured_to_configuring = function()
     helpers.skip_cartridge_version_less("2.0.2")
     helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server("main")
-    main_server:exec(function()
-        local myself = require('membership').myself()
 
-        myself.payload.state='ConfiguringRoles'
-        myself.payload.state_prev='RolesConfigured'
+    main_server:exec(function()
+        local membership = package.loaded['membership']
+        
+        membership.myself = function()
+            return {
+                status = 'alive',
+                payload = {
+                    state='ConfiguringRoles',
+                    state_prev='RolesConfigured',
+                }
+            }
+        end
     end)
 
     local resp = main_server:http_request("get", "/health", {raise = false})
     t.assert_equals(resp.status, 200)
 end
 
-g.test_cartridge_health_handler_member_state_boxconfigured_configuring = function()
+g.test_cartridge_health_handler_member_suspect_state_configured_to_configuring = function()
     helpers.skip_cartridge_version_less("2.0.2")
     helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server("main")
-    main_server:exec(function()
-        local myself = require('membership').myself()
 
-        myself.payload.state='ConfiguringRoles'
-        myself.payload.state_prev='BoxConfigured'
+    main_server:exec(function()
+        local membership = package.loaded['membership']
+        
+        membership.myself = function()
+            return {
+                status = 'suspect',
+                payload = {
+                    state='ConfiguringRoles',
+                    state_prev='RolesConfigured',
+                }
+            }
+        end
+    end)
+
+    local resp = main_server:http_request("get", "/health", {raise = false})
+    t.assert_equals(resp.status, 200)
+end
+
+g.test_cartridge_health_handler_member_alive_state_boxconfigured_to_configuring = function()
+    helpers.skip_cartridge_version_less("2.0.2")
+    helpers.upload_default_metrics_config(g.cluster)
+    local main_server = g.cluster:server("main")
+
+    main_server:exec(function()
+        local membership = package.loaded['membership']
+
+        membership.myself = function()
+            return {
+                status = 'alive',
+                payload = {
+                    state='ConfiguringRoles',
+                    state_prev='BoxConfigured',
+                }
+            }
+        end
+    end)
+
+    local resp = main_server:http_request("get", "/health", {raise = false})
+    t.assert_equals(resp.status, 500)
+end
+
+g.test_cartridge_health_handler_member_suspect_state_boxconfigured_to_configuring = function()
+    helpers.skip_cartridge_version_less("2.0.2")
+    helpers.upload_default_metrics_config(g.cluster)
+    local main_server = g.cluster:server("main")
+
+    main_server:exec(function()
+        local membership = package.loaded['membership']
+
+        membership.myself = function()
+            return {
+                status = 'suspect',
+                payload = {
+                    state='ConfiguringRoles',
+                    state_prev='BoxConfigured',
+                }
+            }
+        end
     end)
 
     local resp = main_server:http_request("get", "/health", {raise = false})

--- a/test/integration/cartridge_health_test.lua
+++ b/test/integration/cartridge_health_test.lua
@@ -43,14 +43,13 @@ g.test_cartridge_health_handler_member_state_configured_configuring = function()
     helpers.skip_cartridge_version_less("2.0.2")
     helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server("main")
-    main_server.net_box:eval(
-        [[
-        myself = require('membership').myself()
+    main_server:exec(function()
+        local myself = require('membership').myself()
 
         myself.payload.state='ConfiguringRoles'
         myself.payload.state_prev='RolesConfigured'
-    ]]
-    )
+    end)
+
     local resp = main_server:http_request("get", "/health", {raise = false})
     t.assert_equals(resp.status, 200)
 end
@@ -59,14 +58,13 @@ g.test_cartridge_health_handler_member_state_boxconfigured_configuring = functio
     helpers.skip_cartridge_version_less("2.0.2")
     helpers.upload_default_metrics_config(g.cluster)
     local main_server = g.cluster:server("main")
-    main_server.net_box:eval(
-        [[
-        myself = require('membership').myself()
+    main_server:exec(function()
+        local myself = require('membership').myself()
 
         myself.payload.state='ConfiguringRoles'
         myself.payload.state_prev='BoxConfigured'
-    ]]
-    )
+    end)
+
     local resp = main_server:http_request("get", "/health", {raise = false})
     t.assert_equals(resp.status, 500)
 end


### PR DESCRIPTION
Use the same logic for `is_healthy` as `member_is_healthy` from [cartridge](https://github.com/tarantool/cartridge/blob/master/cartridge/rpc.lua#L52) to prevent 500 response.