### PR TITLE
api: metrics configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - simultaneous `include` and `exclude` arguments
     (`exclude` has higher priority)
 
+### Deprecated
+- Passing nonexistent metrics to `enable_default_metrics()`
+
 ## [0.16.0] - 2023-01-27
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Setup cartridge hotreload inside the role
 
 ## [0.16.0] - 2023-01-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Setup cartridge hotreload inside the role
+- Extend `enable_default_metrics()` API:
+  - `'all'` and `'none'` options for `include` argument,
+  - simultaneous `include` and `exclude` arguments
+    (`exclude` has higher priority)
 
 ## [0.16.0] - 2023-01-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 - Passing nonexistent metrics to `enable_default_metrics()`
+- Using `{}` as `include` in `enable_default_metrics()`
+  to enable all metrics
 
 ## [0.16.0] - 2023-01-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `metrics.cfg{}` -- a single entrypoint to setup the module:
+  - `include` and `exclude` options with the same effect as in
+    `enable_default_metrics(include, exclude)` (but its deprecated
+    features already disabled);
+  - `labels` options with the same effect as `set_global_labels(labels)`;
+  - values and effect (like default metrics callbacks) are preserved
+    between reloads;
+  - does not deal with external features like cartridge HTTP setup
+
 ### Changed
 - Setup cartridge hotreload inside the role
 - Extend `enable_default_metrics()` API:

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ lint: .rocks
 
 .PHONY: test
 test: .rocks
-	.rocks/bin/luatest -v
+	.rocks/bin/luatest -v -c
 
 .PHONY: test_with_coverage_report
 test_with_coverage_report: .rocks
 	rm -f tmp/luacov.*.out*
-	.rocks/bin/luatest --coverage -v --shuffle group --repeat 3
+	.rocks/bin/luatest --coverage -v -c --shuffle group --repeat 3
 	.rocks/bin/luacov .
 	echo
 	grep -A999 '^Summary' tmp/luacov.report.out

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -1,5 +1,6 @@
 local cartridge = require('cartridge')
 local argparse = require('cartridge.argparse')
+local hotreload_supported, hotreload = pcall(require, 'cartridge.hotreload')
 local metrics = require('metrics')
 local log = require('log')
 
@@ -221,6 +222,10 @@ local function init()
         end
     end
     apply_routes(current_paths)
+
+    if hotreload_supported then
+        hotreload.whitelist_globals({'__metrics_registry'})
+    end
 end
 
 local function stop()

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -136,9 +136,6 @@ local function validate_config(conf_new)
     if type(conf_new['global-labels'] or {}) ~= 'table' then
         error('global-labels section must be a table', 0)
     end
-    if conf_new.exclude ~= nil and conf_new.include ~= nil then
-        error("don't use exclude and include sections together", 0)
-    end
 
     return validate_routes(conf_new.export) and validate_global_labels(conf_new['global-labels'])
 end

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -2,6 +2,7 @@ local cartridge = require('cartridge')
 local argparse = require('cartridge.argparse')
 local hotreload_supported, hotreload = pcall(require, 'cartridge.hotreload')
 local metrics = require('metrics')
+local metrics_stash = require('metrics.stash')
 local log = require('log')
 
 local metrics_vars = require('cartridge.vars').new('metrics_vars')
@@ -222,6 +223,7 @@ local function init()
 
     if hotreload_supported then
         hotreload.whitelist_globals({'__metrics_registry'})
+        metrics_stash.setup_cartridge_reload()
     end
 end
 

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -303,20 +303,25 @@ You can also set global labels by calling
 Metrics functions
 -----------------
 
-..  function:: enable_default_metrics([include, exclude])
+..  function:: cfg([config])
 
-    Enable Tarantool metric collection.
+    Entrypoint to setup the module.
 
-    :param string/table include: ``'all'`` to enable all supported default metrics,
-        ``'none'`` to disable all default metrics,
-        table with names of the default metrics to enable a specific set of metrics
-        (``{}`` is the same as ``'all'`` for backward compatibility).
-        Default is ``'all'``.
+    :param table config: module configuration options:
 
-    :param table exclude: table containing the names of the default metrics that you want to disable.
-        It has higher priority than ``include``. Default is ``{}``.
+      * ``cfg.include`` (string/table, default ``'all'``): ``'all`` to enable all
+        supported default metrics, ``'none'`` to disable all default metrics,
+        table with names of the default metrics to enable a specific set of metrics.
+      * ``cfg.exclude`` (table, default ``{}``): table containing the names of
+        the default metrics that you want to disable. Has higher priority
+        than ``cfg.include``.
+      * ``cfg.labels`` (table, default ``{}``): table containing label names as
+        string keys, label values as values.
 
-    Default metric names:
+    You can work with ``metrics.cfg`` as a table to read values, but you must call
+    ``metrics.cfg{}`` as a function to update them.
+
+    Supported default metric names (for ``cfg.include`` and ``cfg.exclude`` tables):
 
     *   ``network``
     *   ``operations``
@@ -340,12 +345,7 @@ Metrics functions
     See :ref:`metrics reference <metrics-reference>` for details.
     All metric collectors from the collection have ``metainfo.default = true``.
 
-..  function:: set_global_labels(label_pairs)
-
-    Set the global labels to be added to every observation.
-
-    :param table label_pairs: table containing label names as string keys,
-                              label values as values.
+    ``cfg.labels`` are the global labels to be added to every observation.
 
     Global labels are applied only to metric collection. They have no effect
     on how observations are stored.
@@ -357,6 +357,15 @@ Metrics functions
     some global label, the method argument value will be used.
 
     Note that both label names and values in ``label_pairs`` are treated as strings.
+
+..  function:: enable_default_metrics([include, exclude])
+
+    Same as ``metrics.cfg{include=include, exclude=exclude}``, but ``include={}`` is
+    treated as ``include='all'`` for backward compatibility.
+
+..  function:: set_global_labels(label_pairs)
+
+    Same as ``metrics.cfg{labels=label_pairs}``.
 
 ..  function:: collect([opts])
 

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -307,9 +307,14 @@ Metrics functions
 
     Enable Tarantool metric collection.
 
-    :param table include: table containing the names of the default metrics that you need to enable.
+    :param string/table include: ``'all'`` to enable all supported default metrics,
+        ``'none'`` to disable all default metrics,
+        table with names of the default metrics to enable a specific set of metrics
+        (``{}`` is the same as ``'all'`` for backward compatibility).
+        Default is ``'all'``.
 
-    :param table exclude: table containing the names of the default metrics that you need to exclude.
+    :param table exclude: table containing the names of the default metrics that you want to disable.
+        It has higher priority than ``include``. Default is ``{}``.
 
     Default metric names:
 

--- a/doc/monitoring/getting_started.rst
+++ b/doc/monitoring/getting_started.rst
@@ -21,17 +21,12 @@ Next, require it in your code:
 
     local metrics = require('metrics')
 
-Set a global label for your metrics:
+Enable default Tarantool metrics such as network, memory, operations, etc.
+You may also set a global label for your metrics:
 
 ..  code-block:: lua
 
-    metrics.set_global_labels({alias = 'alias'})
-
-Enable default Tarantool metrics such as network, memory, operations, etc.:
-
-.. code-block:: lua
-
-    metrics.enable_default_metrics()
+    metrics.cfg{alias = 'alias'}
 
 Initialize the Prometheus exporter or export metrics in another format:
 

--- a/doc/monitoring/plugins.rst
+++ b/doc/monitoring/plugins.rst
@@ -57,7 +57,7 @@ Sample settings
     ..  code-block:: lua
 
         metrics = require('metrics')
-        metrics.enable_default_metrics()
+        metrics.cfg{}
         prometheus = require('metrics.plugins.prometheus')
         httpd = require('http.server').new('0.0.0.0', 8080)
         httpd:route( { path = '/metrics' }, prometheus.collect_http)
@@ -70,7 +70,7 @@ Sample settings
         cartridge = require('cartridge')
         httpd = cartridge.service_get('httpd')
         metrics = require('metrics')
-        metrics.enable_default_metrics()
+        metrics.cfg{}
         prometheus = require('metrics.plugins.prometheus')
         httpd:route( { path = '/metrics' }, prometheus.collect_http)
 

--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -58,6 +58,8 @@ build = {
         ['metrics.tarantool.luajit']        = 'metrics/tarantool/luajit.lua',
         ['metrics.tarantool.vinyl']         = 'metrics/tarantool/vinyl.lua',
         ['metrics.utils']                   = 'metrics/utils.lua',
+        ['metrics.cfg']                     = 'metrics/cfg.lua',
+        ['metrics.stash']                   = 'metrics/stash.lua',
         ['cartridge.roles.metrics']         = 'cartridge/roles/metrics.lua',
         ['cartridge.health']                = 'cartridge/health.lua',
     }

--- a/metrics/api.lua
+++ b/metrics/api.lua
@@ -17,11 +17,6 @@ registry.callbacks = {}
 
 rawset(_G, '__metrics_registry', registry)
 
-local hotreload = package.loaded['cartridge.hotreload']
-if hotreload ~= nil then
-    hotreload.whitelist_globals({'__metrics_registry'})
-end
-
 local function collectors()
     return registry.collectors
 end

--- a/metrics/cfg.lua
+++ b/metrics/cfg.lua
@@ -1,0 +1,91 @@
+-- Based on https://github.com/tarantool/crud/blob/73bf5bf9353f9b9ee69c95bb14c610be8f2daeac/crud/cfg.lua
+
+local checks = require('checks')
+
+local metrics_api = require('metrics.api')
+local const = require('metrics.const')
+local stash = require('metrics.stash')
+local metrics_tarantool = require('metrics.tarantool')
+
+local function set_defaults_if_empty(cfg)
+    if cfg.include == nil then
+        cfg.include = const.ALL
+    end
+
+    if cfg.exclude == nil then
+        cfg.exclude = {}
+    end
+
+    if cfg.labels == nil then
+        cfg.labels = {}
+    end
+
+    return cfg
+end
+
+local function configure(cfg, opts)
+    if opts.include == nil then
+        opts.include = cfg.include
+    end
+
+    if opts.exclude == nil then
+        opts.exclude = cfg.exclude
+    end
+
+    if opts.labels == nil then
+        opts.labels = cfg.labels
+    end
+
+
+    metrics_tarantool.enable_v2(opts.include, opts.exclude)
+    metrics_api.set_global_labels(opts.labels)
+
+    rawset(cfg, 'include', opts.include)
+    rawset(cfg, 'exclude', opts.exclude)
+    rawset(cfg, 'labels', opts.labels)
+end
+
+local _cfg = set_defaults_if_empty(stash.get(stash.name.cfg))
+local _cfg_internal = stash.get(stash.name.cfg_internal)
+
+if _cfg_internal.initialized then
+    configure(_cfg, {})
+end
+
+local function __call(self, opts)
+    checks('table', {
+        include = '?string|table',
+        exclude = '?table',
+        labels = '?table',
+    })
+
+    opts = table.deepcopy(opts) or {}
+
+    configure(_cfg, opts)
+
+    _cfg_internal.initialized = true
+
+    return self
+end
+
+local function __index(_, key)
+    if _cfg_internal.initialized then
+        return _cfg[key]
+    else
+        error('Call metrics.cfg{} first')
+    end
+end
+
+local function __newindex()
+    error('Use metrics.cfg{} instead')
+end
+
+return {
+    -- Iterating through `metrics.cfg` with pairs is not supported yet.
+    cfg = setmetatable({}, {
+        __index = __index,
+        __newindex = __newindex,
+        __call = __call,
+        __serialize = function() return _cfg end
+    }),
+}

--- a/metrics/const.lua
+++ b/metrics/const.lua
@@ -1,4 +1,7 @@
 return {
     INF = math.huge,
     NAN = math.huge * 0,
+
+    ALL = 'all',
+    NONE = 'none',
 }

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -2,6 +2,7 @@
 
 local api = require('metrics.api')
 local const = require('metrics.const')
+local cfg = require('metrics.cfg')
 local http_middleware = require('metrics.http_middleware')
 local tarantool = require('metrics.tarantool')
 
@@ -25,6 +26,7 @@ return {
     invoke_callbacks = api.invoke_callbacks,
     set_global_labels = api.set_global_labels,
     enable_default_metrics = tarantool.enable,
+    cfg = cfg.cfg,
     http_middleware = http_middleware,
     collect = api.collect,
     VERSION = VERSION,

--- a/metrics/stash.lua
+++ b/metrics/stash.lua
@@ -1,0 +1,48 @@
+-- Based on https://github.com/tarantool/crud/blob/73bf5bf9353f9b9ee69c95bb14c610be8f2daeac/crud/common/stash.lua
+
+local stash = {}
+
+--- Available stashes list.
+--
+-- @tfield string cfg
+--  Stash for metrics module configuration.
+--
+stash.name = {
+    cfg = '__metrics_cfg',
+    cfg_internal = '__metrics_cfg_internal'
+}
+
+--- Setup Tarantool Cartridge reload.
+--
+-- @function setup_cartridge_reload
+--
+-- @return Returns
+--
+function stash.setup_cartridge_reload()
+    local hotreload = require('cartridge.hotreload')
+    for _, name in pairs(stash.name) do
+        hotreload.whitelist_globals({ name })
+    end
+end
+
+--- Get a stash instance, initialize if needed.
+--
+--  Stashes are persistent to package reload.
+--  To use them with Cartridge roles reload,
+--  call `stash.setup_cartridge_reload` in role.
+--
+-- @function get
+--
+-- @string name
+--  Stash identifier. Use one from `stash.name` table.
+--
+-- @treturn table A stash instance.
+--
+function stash.get(name)
+    local instance = rawget(_G, name) or {}
+    rawset(_G, name, instance)
+
+    return instance
+end
+
+return stash

--- a/metrics/tarantool.lua
+++ b/metrics/tarantool.lua
@@ -78,6 +78,9 @@ end
 local function enable(include, exclude)
     -- Compatibility with v1.
     if is_empty_table(include) then
+        log.warn('Providing {} in enable_default_metrics include is treated ' ..
+                 'as a default value now (i.e. include all), ' ..
+                 'but it will change in the future. Use "all" instead')
         include = const.ALL
     end
 

--- a/metrics/tarantool.lua
+++ b/metrics/tarantool.lua
@@ -87,6 +87,11 @@ local function enable(include, exclude)
     return enable_impl(include, exclude, false)
 end
 
+local function enable_v2(include, exclude)
+    return enable_impl(include, exclude, true)
+end
+
 return {
     enable = enable,
+    enable_v2 = enable_v2,
 }

--- a/test/cfg_test.lua
+++ b/test/cfg_test.lua
@@ -1,0 +1,185 @@
+local t = require('luatest')
+local group = t.group('cfg')
+
+local fio = require('fio')
+
+local metrics = require('metrics')
+local utils = require('test.utils')
+
+local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.helper'))))
+
+local function create_server(g)
+    g.tmpdir = fio.tempdir()
+    g.server = t.Server:new({
+        command = fio.pathjoin(
+            fio.dirname(debug.sourcedir()),
+            'test', 'entrypoint', 'srv_basic_pure.lua'
+        ),
+        workdir = g.tmpdir,
+        net_box_port = 3031,
+        net_box_credentials = {user = 'guest', password = nil},
+        env = {
+            LUA_PATH = root .. '/?.lua;' ..
+                root .. '/?/init.lua;' ..
+                root .. '/.rocks/share/tarantool/?.lua'
+        },
+    })
+    g.server:start()
+    t.helpers.retrying({}, function() g.server:connect_net_box() end)
+end
+
+local function clean_server(g)
+    g.server:stop()
+    fio.rmtree(g.tmpdir)
+end
+
+group.before_all(utils.init)
+
+group.before_each(function()
+    -- Reset to defaults.
+    metrics.cfg{
+        include = 'all',
+        exclude = {},
+        labels = {},
+    }
+end)
+
+group.before_test('test_default', create_server)
+
+group.test_default = function(g)
+    local cfg = g.server:eval([[
+        local metrics = require('metrics')
+        return metrics.cfg{}
+    ]])
+
+    t.assert_equals(cfg, {include = 'all', exclude = {}, labels = {}})
+
+    local observations = g.server:eval([[
+        local metrics = require('metrics')
+        return metrics.collect{invoke_callbacks = true}
+    ]])
+
+    local expected_metrics = {
+        'tnt_info_uptime', 'tnt_info_memory_lua',
+        'tnt_net_sent_total', 'tnt_slab_arena_used',
+    }
+
+    for _, expected in ipairs(expected_metrics) do
+        local obs = utils.find_metric(expected, observations)
+        t.assert_not_equals(obs, nil, ("metric %q found"):format(expected))
+    end
+end
+
+group.after_test('test_default', clean_server)
+
+group.before_test('test_read_before_init', create_server)
+
+group.test_read_before_init = function(g)
+    t.assert_error_msg_contains(
+        'Call metrics.cfg{} first',
+        function()
+            g.server:eval([[
+                local metrics = require('metrics')
+                return metrics.cfg.include
+            ]])
+        end)
+end
+
+group.after_test('test_read_before_init', clean_server)
+
+group.test_table_value = function()
+    metrics.cfg{
+        include = {'info'}
+    }
+    t.assert_equals(metrics.cfg.include, {'info'})
+end
+
+group.test_change_value = function()
+    local cfg = metrics.cfg{
+        include = {'info'},
+    }
+    t.assert_equals(cfg['include'], {'info'})
+end
+
+group.test_table_is_immutable = function()
+    t.assert_error_msg_contains(
+        'Use metrics.cfg{} instead',
+        function()
+            metrics.cfg.include = {'info'}
+        end
+    )
+
+    t.assert_error_msg_contains(
+        'Use metrics.cfg{} instead',
+        function()
+            metrics.cfg.newfield = 'newvalue'
+        end
+    )
+end
+
+group.test_include = function()
+    metrics.cfg{
+        include = {'info'},
+    }
+
+    local default_metrics = metrics.collect{invoke_callbacks = true}
+    local uptime = utils.find_metric('tnt_info_uptime', default_metrics)
+    t.assert_not_equals(uptime, nil)
+    local memlua = utils.find_metric('tnt_info_memory_lua', default_metrics)
+    t.assert_equals(memlua, nil)
+end
+
+group.test_exclude = function()
+    metrics.cfg{
+        exclude = {'memory'},
+    }
+
+    local default_metrics = metrics.collect{invoke_callbacks = true}
+    local uptime = utils.find_metric('tnt_info_uptime', default_metrics)
+    t.assert_not_equals(uptime, nil)
+    local memlua = utils.find_metric('tnt_info_memory_lua', default_metrics)
+    t.assert_equals(memlua, nil)
+end
+
+group.test_include_with_exclude = function()
+    metrics.cfg{
+        include = {'info', 'memory'},
+        exclude = {'memory'},
+    }
+
+    local default_metrics = metrics.collect{invoke_callbacks = true}
+    local uptime = utils.find_metric('tnt_info_uptime', default_metrics)
+    t.assert_not_equals(uptime, nil)
+    local memlua = utils.find_metric('tnt_info_memory_lua', default_metrics)
+    t.assert_equals(memlua, nil)
+end
+
+group.test_include_none = function()
+    metrics.cfg{
+        include = 'none',
+        exclude = {'memory'},
+    }
+
+    local default_metrics = metrics.collect{invoke_callbacks = true}
+    t.assert_equals(default_metrics, {})
+end
+
+group.test_labels = function()
+    metrics.cfg{
+        labels = {mylabel = 'myvalue'},
+    }
+
+    local default_metrics = metrics.collect{invoke_callbacks = true}
+    local uptime = utils.find_obs('tnt_info_uptime', {mylabel = 'myvalue'}, default_metrics)
+    t.assert_equals(uptime.label_pairs, {mylabel = 'myvalue'})
+
+    metrics.cfg{
+        labels = {},
+    }
+
+    default_metrics = metrics.collect{invoke_callbacks = true}
+    uptime = utils.find_obs('tnt_info_uptime', {}, default_metrics)
+    t.assert_equals(uptime.label_pairs, {})
+end
+
+

--- a/test/enable_default_metrics_test.lua
+++ b/test/enable_default_metrics_test.lua
@@ -1,0 +1,116 @@
+#!/usr/bin/env tarantool
+
+local t = require('luatest')
+local g = t.group('enable_default_metrics')
+
+local metrics = require('metrics')
+local utils = require('test.utils')
+
+g.before_all(utils.init)
+
+g.after_each(function()
+    metrics.clear()
+end)
+
+local cases = {
+    default = {
+        include = nil,
+        exclude = nil,
+        expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+        not_expected = {},
+    },
+    v1_compatibility = {
+        include = {},
+        exclude = nil,
+        expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+        not_expected = {},
+    },
+    include_all = {
+        include = 'all',
+        exclude = nil,
+        expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+        not_expected = {},
+    },
+    include_list = {
+        include = { 'info', 'memory' },
+        exclude = nil,
+        expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+        },
+        not_expected = {
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+    },
+    include_none = {
+        include = 'none',
+        exclude = nil,
+        expected = {},
+        not_expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+    },
+    exclude_from_all = {
+        include = 'all',
+        exclude = { 'memory' },
+        expected = {
+            'tnt_info_uptime', 'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+        not_expected = {
+            'tnt_info_memory_lua',
+        },
+    },
+    exclude_from_list = {
+        include = { 'info', 'memory', 'network' },
+        exclude = { 'network', 'memory' },
+        expected = {
+            'tnt_info_uptime',
+        },
+        not_expected = {
+            'tnt_info_memory_lua', 'tnt_net_sent_total',
+        },
+    },
+    exclude_not_enabled = {
+        include = { 'info' },
+        exclude = { 'memory' },
+        expected = {
+            'tnt_info_uptime',
+        },
+        not_expected = {
+            'tnt_info_memory_lua',
+        },
+    },
+}
+
+for name, case in pairs(cases) do
+    g['test_' .. name] = function()
+        metrics.enable_default_metrics(case.include, case.exclude)
+
+        local observations = metrics.collect{invoke_callbacks = true}
+
+        for _, expected in ipairs(case.expected) do
+            local obs = utils.find_metric(expected, observations)
+            t.assert_not_equals(obs, nil, ("metric %q found"):format(expected))
+        end
+
+        for _, not_expected in ipairs(case.not_expected) do
+            local obs = utils.find_metric(not_expected, observations)
+            t.assert_equals(obs, nil, ("metric %q not found"):format(not_expected))
+        end
+    end
+end
+
+g.test_invalid_include = function()
+    t.assert_error_msg_contains(
+        'Unexpected value provided: include must be "all", {...} or "none"',
+        metrics.enable_default_metrics, 'everything')
+end

--- a/test/entrypoint/srv_basic_pure.lua
+++ b/test/entrypoint/srv_basic_pure.lua
@@ -1,0 +1,9 @@
+#!/usr/bin/env tarantool
+
+local workdir = os.getenv('TARANTOOL_WORKDIR')
+local listen = os.getenv('TARANTOOL_LISTEN')
+local log = os.getenv('TARANTOOL_LOG')
+
+box.cfg({work_dir = workdir, log = log})
+box.schema.user.grant('guest', 'super', nil, nil, {if_not_exists=true})
+box.cfg({listen = listen})

--- a/test/integration/hotreload_test.lua
+++ b/test/integration/hotreload_test.lua
@@ -5,6 +5,18 @@ local fio = require('fio')
 local t = require('luatest')
 local g = t.group('hotreload')
 
+local utils = require('test.utils')
+
+local function package_reload()
+    for k, _ in pairs(package.loaded) do
+        if k:find('metrics') ~= nil then
+            package.loaded[k] = nil
+        end
+    end
+
+    return require('metrics')
+end
+
 g.test_reload = function()
     local tmpdir = fio.tempdir()
     if type(box.cfg) == 'function' then
@@ -27,13 +39,29 @@ g.test_reload = function()
 
     metrics.enable_default_metrics()
 
-    for k, _ in pairs(package.loaded) do
-        if k:find('metrics') ~= nil then
-            package.loaded[k] = nil
-        end
-    end
-
-    metrics = require('metrics')
+    metrics = package_reload()
 
     metrics.enable_default_metrics()
+end
+
+g.test_cartridge_hotreload_preserves_cfg_state = function()
+    local metrics = require('metrics')
+
+    local cfg_before_hotreload = metrics.cfg{include = {'operations'}}
+    local obs_before_hotreload = metrics.collect{invoke_callbacks = true}
+
+    metrics = package_reload()
+
+    local cfg_after_hotreload = metrics.cfg
+    box.space._space:select(nil, {limit = 1})
+    local obs_after_hotreload = metrics.collect{invoke_callbacks = true}
+
+    t.assert_equals(cfg_before_hotreload, cfg_after_hotreload,
+        "cfg values are preserved")
+
+    local op_before = utils.find_obs('tnt_stats_op_total', {operation = 'select'},
+        obs_before_hotreload, t.assert_covers)
+    local op_after = utils.find_obs('tnt_stats_op_total', {operation = 'select'},
+        obs_after_hotreload, t.assert_covers)
+    t.assert_gt(op_after.value, op_before.value, "metric callbacks enabled by cfg stay enabled")
 end

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -3,6 +3,9 @@ local t = require('luatest')
 local fun = require('fun')
 local metrics = require('metrics')
 local fio = require('fio')
+local clock = require('clock')
+local fiber = require('fiber')
+local log = require('log')
 
 local utils = {}
 
@@ -104,6 +107,32 @@ function utils.clear_spaces()
             v:drop()
         end
     end
+end
+
+-- Based on https://github.com/tarantool/crud/blob/5717e87e1f8a6fb852c26181524fafdbc7a472d8/test/helper.lua#L533-L544
+function utils.fflush_main_server_output(server, capture)
+    -- Sometimes we have a delay here. This hack helps to wait for the end of
+    -- the output. It shouldn't take much time.
+    local helper_msg = "metrics fflush message"
+    if server then
+        server.net_box:eval([[
+            require('log').error(...)
+        ]], {helper_msg})
+    else
+        log.error(helper_msg)
+    end
+
+    local max_wait_timeout = 10
+    local start_time = clock.monotonic()
+
+    local captured = ""
+    while (not string.find(captured, helper_msg, 1, true))
+    and (clock.monotonic() - start_time < max_wait_timeout) do
+        local captured_part = capture:flush()
+        captured = captured .. (captured_part.stdout or "") .. (captured_part.stderr or "")
+        fiber.yield()
+    end
+    return captured
 end
 
 return utils

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -22,9 +22,11 @@ function utils.init()
     }
 end
 
-function utils.find_obs(metric_name, label_pairs, observations)
+function utils.find_obs(metric_name, label_pairs, observations, comparator)
+    comparator = comparator or t.assert_equals
+
     for _, obs in pairs(observations) do
-        local same_label_pairs = pcall(t.assert_equals, obs.label_pairs, label_pairs)
+        local same_label_pairs = pcall(comparator, obs.label_pairs, label_pairs)
         if obs.metric_name == metric_name and same_label_pairs then
             return obs
         end


### PR DESCRIPTION
This PR introduces `metrics.cfg{}` -- a single entrypoint to setup the module:
- `include` and `exclude` options with the same effect as in `enable_default_metrics(include, exclude)`;
- `labels` options with the same effect as `set_global_labels(labels)`;
- values and effect (like default metrics callbacks) are preserved between reloads;
- does not deal with external features like cartridge HTTP setup.

It is a prerequirement to `box.cfg{}` metrics configuration after embedding.

Some features were deprecated to make API more consistent and stable:
- explicit `{}` `include` with the default meaning ("include all"),
- invalid metric names.

Using the deprecated features logs warning for existing handles and throw errors for new API like `metrics.cfg{}`.

See comments for more info.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rst)
- [x] Rockspec and rpm spec

Part of tarantool/tarantool#7725