### PR TITLE
New version module info & Release 0.16.0

### DIFF
--- a/.github/workflows/push_rockspec.yml
+++ b/.github/workflows/push_rockspec.yml
@@ -41,7 +41,6 @@ jobs:
             -e "s/branch = '.\+'/tag = '${GIT_TAG}'/g" \
             -e "s/version = '.\+'/version = '${GIT_TAG}-1'/g" \
             ${{ env.ROCK_NAME }}-scm-1.rockspec > ${{ env.ROCK_NAME }}-${GIT_TAG}-1.rockspec
-          sed -i "s/local VERSION = 'scm-1'/local VERSION = '"${GIT_TAG}"-1'/g" metrics/init.lua
 
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2023-01-27
 ### Added
 
 - Handle to clear psutils metrics

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -10,7 +10,7 @@ local Gauge = require('metrics.collectors.gauge')
 local Histogram = require('metrics.collectors.histogram')
 local Summary = require('metrics.collectors.summary')
 
-local VERSION = '0.15.1-scm'
+local VERSION = '0.16.0'
 
 local registry = rawget(_G, '__metrics_registry')
 if not registry then

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -10,7 +10,7 @@ local Gauge = require('metrics.collectors.gauge')
 local Histogram = require('metrics.collectors.histogram')
 local Summary = require('metrics.collectors.summary')
 
-local VERSION = 'scm-1'
+local VERSION = '0.15.1-scm'
 
 local registry = rawget(_G, '__metrics_registry')
 if not registry then

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -156,4 +156,5 @@ return {
     http_middleware = require('metrics.http_middleware'),
     collect = collect,
     VERSION = VERSION,
+    _VERSION = VERSION,
 }


### PR DESCRIPTION
This patch introduces the fix of existing module version info together with new version providing policy (potentially temporary). It is a prerequirement to tarantool/tarantool#8192.

New `VERSION`/`_VERSION` is a plain Lua string controlled by the developer.

The rules are as follows:
- bump version to X.Y.Z in release commit,
- bump version to X.Y.Z-scm in the following commit.

`luarocks.core.vers` comparison treats scm version as we expect them to:
- X.Y.Z-scm > X.Y.Z
- X.Y.Z+1 > X.Y.Z-scm
- X.Y+1.0 > X.Y.Z-scm
- X+1.0.0 > X.Y.Z-scm

This PR is also a 0.16.0 release patch.

I didn't forget about

- Tests (I think it's not worth it)
- [x] Changelog
- Documentation (README and rst)
- Rockspec and rpm spec

Close #330, part of tarantool/tarantool#8192
