### PR TITLE
Rework flaky psutils test 

### DIFF
--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -10,7 +10,7 @@ local Gauge = require('metrics.collectors.gauge')
 local Histogram = require('metrics.collectors.histogram')
 local Summary = require('metrics.collectors.summary')
 
-local VERSION = '0.16.0'
+local VERSION = '0.16.0-scm'
 
 local registry = rawget(_G, '__metrics_registry')
 if not registry then

--- a/test/psutils_linux_thread_clean_test.lua
+++ b/test/psutils_linux_thread_clean_test.lua
@@ -4,9 +4,6 @@ local t = require('luatest')
 local g = t.group('psutils_linux_clean_info')
 local utils = require('test.utils')
 local metrics = require('metrics')
-local fiber = require('fiber')
-local fio = require('fio')
-local psutils_linux = require('metrics.psutils.psutils_linux')
 local cpu = require('metrics.psutils.cpu')
 
 g.before_all(function()
@@ -19,40 +16,21 @@ g.after_each(function()
 end)
 
 g.test_clean_thread_info = function()
-    box.cfg{worker_pool_threads = 100}
-
-    for _ = 1, 1000 do
-        fiber.new(function() fio.stat(arg[-1]) end)
-    end
-    fiber.sleep(0.1)
-
     cpu.update()
-    local list1 = psutils_linux.get_process_cpu_time()
-    local observations1 = metrics.collect()
-    local coio_count1 = 0
-    for _, thread_info in ipairs(list1) do
-        if thread_info.comm == 'coio' then
-            coio_count1 = coio_count1 + 1
-        end
+    local observations = metrics.collect()
+
+    local thread_obs = utils.find_metric('tnt_cpu_thread', observations)
+    t.assert_not_equals(thread_obs, nil)
+
+    local threads = {}
+    for _, obs in ipairs(thread_obs) do
+        threads[obs.label_pairs.thread_name] = true
     end
 
-    box.cfg{worker_pool_threads = 1}
-    fiber.sleep(0.1)
-
-    cpu.update()
-    local list2 = psutils_linux.get_process_cpu_time()
-    local observations2 = metrics.collect()
-    local coio_count2 = 0
-    for _, thread_info in ipairs(list2) do
-        if thread_info.comm == 'coio' then
-            coio_count2 = coio_count2 + 1
-        end
-    end
-
-    t.assert_gt(#list1, #list2)
-    t.assert_gt(#observations1, #observations2)
-    t.assert_gt(coio_count1, coio_count2)
-    t.assert_equals(#observations1 - #observations2, 2 * (coio_count1 - coio_count2))
+    -- After box.cfg{}, there should be at least tx (tarantool), iproto and wal.
+    t.assert_ge(utils.len(threads), 3)
+    t.assert_equals(#thread_obs, 2 * utils.len(threads),
+        'There are two observations for each thread (user and system)')
 end
 
 g.test_cpu_count = function()


### PR DESCRIPTION
`psutils_linux_clean_info.test_clean_thread_info` is a test that sometimes failed on CI runs, see [1] for example. You cannot guarantee that the quantity of `coio` threads would be bigger for `{worker_pool_threads = 100}` rather than `{worker_pool_threads = 1}`, since it defines only the upper threshold. The new version of the test checks that there are at least three threads in metrics (after `box.cfg{}`, there should be at least `tx`, `iproto` and `wal`) and each thread has system and user time metrics.

1. https://github.com/tarantool/metrics/actions/runs/4015805052/jobs/6897997400#step:7:254

I didn't forget about

- [x] Tests
- Changelog (not a user visible change)
- Documentation (README and rst) (not a user visible change)
- Rockspec and rpm spec (not needed)

Part of tarantool/tarantool#7725
