### PR TITLE
test: fix using legacy approach in hooks

### DIFF
--- a/test/collectors/summary_test.lua
+++ b/test/collectors/summary_test.lua
@@ -7,9 +7,7 @@ local Summary = require('metrics.collectors.summary')
 local Quantile = require('metrics.quantile')
 local metrics = require('metrics')
 
-g.before_each = function()
-    metrics.clear()
-end
+g.before_each(metrics.clear)
 
 g.test_collect = function()
     local instance = Summary:new('latency', nil, {[0.5]=0.01, [0.9]=0.01, [0.99]=0.01})

--- a/test/unit/cartridge_issues_test.lua
+++ b/test/unit/cartridge_issues_test.lua
@@ -3,10 +3,10 @@ local helpers = require('test.helper')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
     helpers.skip_cartridge_version_less('2.0.2')
-end
+end)
 
 g.test_cartridge_issues_before_cartridge_cfg = function()
     require('cartridge.issues')

--- a/test/unit/cartridge_role_test.lua
+++ b/test/unit/cartridge_role_test.lua
@@ -5,17 +5,17 @@ local helpers = require('test.helper')
 local t = require('luatest')
 local g = t.group()
 
-g.before_all = function()
+g.before_all(function()
     t.skip_if(type(helpers) ~= 'table', 'Skip cartridge test')
-end
+end)
 
-g.after_each = function()
+g.after_each(function()
     metrics.clear()
-end
+end)
 
-g.after_all = function()
+g.after_all(function()
     package.loaded['cartridge.argparse'] = nil
-end
+end)
 
 local function mock_argparse(params)
     package.loaded['cartridge.argparse'] = {


### PR DESCRIPTION
`g.before_all = function(g) ... end` is a legacy approach and may be deprecated in the future [1]. `g.before_all(function(g) ... end)` is preferred since it allows to set multiple hooks. Moreover, this behavior is not supported in newer `before_each`/`after_each` hooks, so they weren't even executed before this patch.

1. https://github.com/tarantool/luatest/blob/master/CHANGELOG.md#040

I didn't forget about

- [x] Tests
- Changelog (not a user-visible change)
- Documentation (README and rst) (not needed)
- Rockspec and rpm spec (not needed)
