### PR TITLE
internal: remove circular dependencies

### DIFF
--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -23,6 +23,7 @@ build = {
 
     modules = {
         ['metrics']                         = 'metrics/init.lua',
+        ['metrics.api']                     = 'metrics/api.lua',
         ['metrics.registry']                = 'metrics/registry.lua',
         ['metrics.quantile']                = 'metrics/quantile.lua',
         ['metrics.http_middleware']         = 'metrics/http_middleware.lua',

--- a/metrics/api.lua
+++ b/metrics/api.lua
@@ -1,0 +1,148 @@
+-- vim: ts=4:sw=4:sts=4:expandtab
+
+local checks = require('checks')
+
+local Registry = require('metrics.registry')
+
+local Counter = require('metrics.collectors.counter')
+local Gauge = require('metrics.collectors.gauge')
+local Histogram = require('metrics.collectors.histogram')
+local Summary = require('metrics.collectors.summary')
+
+local registry = rawget(_G, '__metrics_registry')
+if not registry then
+    registry = Registry.new()
+end
+registry.callbacks = {}
+
+rawset(_G, '__metrics_registry', registry)
+
+local hotreload = package.loaded['cartridge.hotreload']
+if hotreload ~= nil then
+    hotreload.whitelist_globals({'__metrics_registry'})
+end
+
+local function collectors()
+    return registry.collectors
+end
+
+local function register_callback(...)
+    return registry:register_callback(...)
+end
+
+local function unregister_callback(...)
+    return registry:unregister_callback(...)
+end
+
+local function invoke_callbacks()
+    return registry:invoke_callbacks()
+end
+
+local function get_collector_values(collector, result)
+    for _, obs in ipairs(collector:collect()) do
+        table.insert(result, obs)
+    end
+end
+
+local function collect(opts)
+    checks({invoke_callbacks = '?boolean', default_only = '?boolean'})
+    opts = opts or {}
+
+    if opts.invoke_callbacks then
+        registry:invoke_callbacks()
+    end
+
+    local result = {}
+    for _, collector in pairs(registry.collectors) do
+        if opts.default_only then
+            if collector.metainfo.default then
+                get_collector_values(collector, result)
+            end
+        else
+            get_collector_values(collector, result)
+        end
+    end
+
+    return result
+end
+
+local function clear()
+    registry:clear()
+end
+
+local function counter(name, help, metainfo)
+    checks('string', '?string', '?table')
+
+    return registry:find_or_create(Counter, name, help, metainfo)
+end
+
+local function gauge(name, help, metainfo)
+    checks('string', '?string', '?table')
+
+    return registry:find_or_create(Gauge, name, help, metainfo)
+end
+
+local function histogram(name, help, buckets, metainfo)
+    checks('string', '?string', '?table', '?table')
+    if buckets ~= nil and not Histogram.check_buckets(buckets) then
+        error('Invalid value for buckets')
+    end
+
+    return registry:find_or_create(Histogram, name, help, buckets, metainfo)
+end
+
+local function summary(name, help, objectives, params, metainfo)
+    checks('string', '?string', '?table', {
+        age_buckets_count = '?number',
+        max_age_time = '?number',
+    }, '?table')
+    if objectives ~= nil and not Summary.check_quantiles(objectives) then
+        error('Invalid value for objectives')
+    end
+    params = params or {}
+    local age_buckets_count = params.age_buckets_count
+    local max_age_time = params.max_age_time
+    if max_age_time and max_age_time <= 0 then
+        error('Max age must be positive')
+    end
+    if age_buckets_count and age_buckets_count < 1 then
+        error('Age buckets count must be greater or equal than one')
+    end
+    if (max_age_time and not age_buckets_count) or (not max_age_time and age_buckets_count) then
+        error('Age buckets count and max age must be present only together')
+    end
+
+    return registry:find_or_create(Summary, name, help, objectives, params, metainfo)
+end
+
+local function set_global_labels(label_pairs)
+    checks('?table')
+
+    label_pairs = label_pairs or {}
+
+    -- Verify label table
+    for k, _ in pairs(label_pairs) do
+        if type(k) ~= 'string' then
+            error(("bad label key (string expected, got %s)"):format(type(k)))
+        end
+    end
+
+    registry:set_labels(label_pairs)
+end
+
+return {
+    registry = registry,
+    collectors = collectors,
+
+    counter = counter,
+    gauge = gauge,
+    histogram = histogram,
+    summary = summary,
+
+    collect = collect,
+    clear = clear,
+    register_callback = register_callback,
+    unregister_callback = unregister_callback,
+    invoke_callbacks = invoke_callbacks,
+    set_global_labels = set_global_labels,
+}

--- a/metrics/http_middleware.lua
+++ b/metrics/http_middleware.lua
@@ -1,6 +1,13 @@
 local export = {}
 local log = require('log')
 
+local metrics_api = require('metrics.api')
+
+local collector_type = {
+    histogram = require('metrics.collectors.histogram'),
+    summary = require('metrics.collectors.summary'),
+}
+
 export.DEFAULT_HISTOGRAM_BUCKETS = {
     0.001,  0.0025, 0.005,  0.0075,
     0.01,   0.025,  0.05,   0.075,
@@ -38,8 +45,7 @@ function export.build_default_collector(type_name, name, help)
     else
         error('Unknown collector type_name: ' .. tostring(type_name))
     end
-    local class = require('metrics.collectors.' .. type_name)
-    return require('metrics').registry:register(class:new(name, help, unpack(extra)))
+    return metrics_api.registry:register(collector_type[type_name]:new(name, help, unpack(extra)))
 end
 
 function export.get_default_collector()

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -1,160 +1,32 @@
 -- vim: ts=4:sw=4:sts=4:expandtab
 
-local checks = require('checks')
-
-local Const = require('metrics.const')
-local Registry = require('metrics.registry')
-
-local Counter = require('metrics.collectors.counter')
-local Gauge = require('metrics.collectors.gauge')
-local Histogram = require('metrics.collectors.histogram')
-local Summary = require('metrics.collectors.summary')
+local api = require('metrics.api')
+local const = require('metrics.const')
+local http_middleware = require('metrics.http_middleware')
+local tarantool = require('metrics.tarantool')
 
 local VERSION = '0.16.0-scm'
 
-local registry = rawget(_G, '__metrics_registry')
-if not registry then
-    registry = Registry.new()
-end
-registry.callbacks = {}
-
-rawset(_G, '__metrics_registry', registry)
-
-local hotreload = package.loaded['cartridge.hotreload']
-if hotreload ~= nil then
-    hotreload.whitelist_globals({'__metrics_registry'})
-end
-
-local function collectors()
-    return registry.collectors
-end
-
-local function register_callback(...)
-    return registry:register_callback(...)
-end
-
-local function unregister_callback(...)
-    return registry:unregister_callback(...)
-end
-
-local function invoke_callbacks()
-    return registry:invoke_callbacks()
-end
-
-local function get_collector_values(collector, result)
-    for _, obs in ipairs(collector:collect()) do
-        table.insert(result, obs)
-    end
-end
-
-local function collect(opts)
-    checks({invoke_callbacks = '?boolean', default_only = '?boolean'})
-    opts = opts or {}
-
-    if opts.invoke_callbacks then
-        registry:invoke_callbacks()
-    end
-
-    local result = {}
-    for _, collector in pairs(registry.collectors) do
-        if opts.default_only then
-            if collector.metainfo.default then
-                get_collector_values(collector, result)
-            end
-        else
-            get_collector_values(collector, result)
-        end
-    end
-
-    return result
-end
-
-local function clear()
-    registry:clear()
-end
-
-local function counter(name, help, metainfo)
-    checks('string', '?string', '?table')
-
-    return registry:find_or_create(Counter, name, help, metainfo)
-end
-
-local function gauge(name, help, metainfo)
-    checks('string', '?string', '?table')
-
-    return registry:find_or_create(Gauge, name, help, metainfo)
-end
-
-local function histogram(name, help, buckets, metainfo)
-    checks('string', '?string', '?table', '?table')
-    if buckets ~= nil and not Histogram.check_buckets(buckets) then
-        error('Invalid value for buckets')
-    end
-
-    return registry:find_or_create(Histogram, name, help, buckets, metainfo)
-end
-
-local function summary(name, help, objectives, params, metainfo)
-    checks('string', '?string', '?table', {
-        age_buckets_count = '?number',
-        max_age_time = '?number',
-    }, '?table')
-    if objectives ~= nil and not Summary.check_quantiles(objectives) then
-        error('Invalid value for objectives')
-    end
-    params = params or {}
-    local age_buckets_count = params.age_buckets_count
-    local max_age_time = params.max_age_time
-    if max_age_time and max_age_time <= 0 then
-        error('Max age must be positive')
-    end
-    if age_buckets_count and age_buckets_count < 1 then
-        error('Age buckets count must be greater or equal than one')
-    end
-    if (max_age_time and not age_buckets_count) or (not max_age_time and age_buckets_count) then
-        error('Age buckets count and max age must be present only together')
-    end
-
-    return registry:find_or_create(Summary, name, help, objectives, params, metainfo)
-end
-
-local function set_global_labels(label_pairs)
-    checks('?table')
-
-    label_pairs = label_pairs or {}
-
-    -- Verify label table
-    for k, _ in pairs(label_pairs) do
-        if type(k) ~= 'string' then
-            error(("bad label key (string expected, got %s)"):format(type(k)))
-        end
-    end
-
-    registry:set_labels(label_pairs)
-end
-
 return {
-    registry = registry,
+    registry = api.registry,
 
-    counter = counter,
-    gauge = gauge,
-    histogram = histogram,
-    summary = summary,
+    counter = api.counter,
+    gauge = api.gauge,
+    histogram = api.histogram,
+    summary = api.summary,
 
-    INF = Const.INF,
-    NAN = Const.NAN,
+    INF = const.INF,
+    NAN = const.NAN,
 
-    clear = clear,
-    collectors = collectors,
-    register_callback = register_callback,
-    unregister_callback = unregister_callback,
-    invoke_callbacks = invoke_callbacks,
-    set_global_labels = set_global_labels,
-    enable_default_metrics = function(include, exclude)
-        require('metrics.tarantool').enable(include, exclude)
-    end,
-    http_middleware = require('metrics.http_middleware'),
-    collect = collect,
+    clear = api.clear,
+    collectors = api.collectors,
+    register_callback = api.register_callback,
+    unregister_callback = api.unregister_callback,
+    invoke_callbacks = api.invoke_callbacks,
+    set_global_labels = api.set_global_labels,
+    enable_default_metrics = tarantool.enable,
+    http_middleware = http_middleware,
+    collect = api.collect,
     VERSION = VERSION,
     _VERSION = VERSION,
 }

--- a/metrics/tarantool.lua
+++ b/metrics/tarantool.lua
@@ -1,4 +1,4 @@
-local metrics = require('metrics')
+local metrics_api = require('metrics.api')
 local utils = require('metrics.utils')
 
 local default_metrics = {
@@ -41,20 +41,20 @@ local function enable(include, exclude)
     for name, value in pairs(default_metrics) do
         if next(include) ~= nil then
             if include_map[name] ~= nil then
-                metrics.register_callback(value.update)
+                metrics_api.register_callback(value.update)
             else
-                metrics.unregister_callback(value.update)
+                metrics_api.unregister_callback(value.update)
                 utils.delete_collectors(value.list)
             end
         elseif next(exclude) ~= nil then
             if exclude_map[name] ~= nil then
-                metrics.unregister_callback(value.update)
+                metrics_api.unregister_callback(value.update)
                 utils.delete_collectors(value.list)
             else
-                metrics.register_callback(value.update)
+                metrics_api.register_callback(value.update)
             end
         else
-            metrics.register_callback(value.update)
+            metrics_api.register_callback(value.update)
         end
     end
 end

--- a/metrics/utils.lua
+++ b/metrics/utils.lua
@@ -1,18 +1,18 @@
-local metrics = require('metrics')
+local metrics_api = require('metrics.api')
 
 local TNT_PREFIX = 'tnt_'
 local utils = {}
 
 function utils.set_gauge(name, description, value, labels, prefix, metainfo)
     prefix = prefix or TNT_PREFIX
-    local gauge = metrics.gauge(prefix .. name, description, metainfo)
+    local gauge = metrics_api.gauge(prefix .. name, description, metainfo)
     gauge:set(value, labels or {})
     return gauge
 end
 
 function utils.set_counter(name, description, value, labels, prefix, metainfo)
     prefix = prefix or TNT_PREFIX
-    local counter = metrics.counter(prefix .. name, description, metainfo)
+    local counter = metrics_api.counter(prefix .. name, description, metainfo)
     counter:reset(labels or {})
     counter:inc(value, labels or {})
     return counter
@@ -31,7 +31,7 @@ function utils.delete_collectors(list)
         return
     end
     for _, collector in pairs(list) do
-        metrics.registry:unregister(collector)
+        metrics_api.registry:unregister(collector)
     end
     table.clear(list)
 end


### PR DESCRIPTION
This PR removes existing circular dependencies in module, as well as remaining `require`s inside the functions.

Before:

![image](https://user-images.githubusercontent.com/20455996/216110367-f146ce44-d549-4c7d-81c9-a6a78835e07a.png)

After:

![image](https://user-images.githubusercontent.com/20455996/216111308-470f5435-b915-4949-8157-4ad3c4dc30bb.png)

(Still seems confusing, but at least more hierarchic.)

It is a prerequirement to `metrics.cfg{}` reload support.

I didn't forget about

- Tests (still green)
- Changelog (internal)
- Documentation (README and rst) (internal)
- [x] Rockspec and rpm spec

Closes #433, part of tarantool/tarantool#7725
