### PR TITLE
api: new export format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passing nonexistent metrics to `enable_default_metrics()`
 - Using `{}` as `include` in `enable_default_metrics()`
   to enable all metrics
+- Control characters in collector kind, name, observation and global labels
 
 ## [0.16.0] - 2023-01-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - values and effect (like default metrics callbacks) are preserved
     between reloads;
   - does not deal with external features like cartridge HTTP setup
+- name prefixes for collectors
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     between reloads;
   - does not deal with external features like cartridge HTTP setup
 - name prefixes for collectors
+- exhaustive output for export and aggregating with `extended_format` option:
+  - `shared_collector_obj:collect()`;
+  - `counter_obj:collect()`;
+  - `gauge_obj:collect()`;
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `counter_obj:collect()`;
   - `gauge_obj:collect()`;
   - `histogram_obj:collect()`;
+  - `summary_obj:collect()`;
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `shared_collector_obj:collect()`;
   - `counter_obj:collect()`;
   - `gauge_obj:collect()`;
+  - `histogram_obj:collect()`;
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `gauge_obj:collect()`;
   - `histogram_obj:collect()`;
   - `summary_obj:collect()`;
+  - `metrics.collect()`;
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -209,11 +209,57 @@ histogram
                                   Note that both label names and values in ``label_pairs``
                                   are treated as strings.
 
-    ..  method:: collect()
+    ..  method:: collect(opts)
 
-        Return a concatenation of ``counter_obj:collect()`` across all internal
-        counters of ``histogram_obj``. For the description of ``observation``,
-        see :ref:`counter_obj:collect() <metrics-api_reference-counter_collect>`.
+        :param table opts: table of collect options:
+
+          * ``extended_format`` -- use extended format in the output.
+
+        :return: A concatenation of ``observation`` objects for a given counter (by default or if
+          ``extended format`` is ``false``). Otherwise returns a map with collector
+          description and structured observations.
+
+        ..  code-block:: lua
+
+            histogram_obj:collect{extended_format = false}
+
+            {
+                -- an observation
+                {
+                    label_pairs: table,          -- `label_pairs` key-value table
+                    timestamp: ctype<uint64_t>,  -- observation time (in microseconds)
+                    value: number,               -- current value
+                    metric_name: string,         -- metric name
+                },
+                -- another observation...
+            }
+
+        ..  code-block:: lua
+
+            histogram_obj:collect{extended_format = true}
+
+            {
+                name: string, -- collector name
+                name_prefix: string, -- collector name_prefix
+                kind: string, -- collector kind
+                help: string, -- collector help
+                metainfo: table, -- collector metainfo
+                timestamp: ctype<uint64_t>,  -- observation time (in microseconds)
+                observations = {
+                    count = { -- map of count observations
+                        -- an observation
+                        key: string = {
+                            label_pairs: table,          -- `label_pairs` key-value table
+                            value: number,               -- current value
+                        },
+                        -- another observation...
+                    },
+                    sum = { -- map of sum observations
+                    },
+                    bucket = { -- map of bucket observations
+                    },
+                }
+            }
 
     ..  method:: remove(label_pairs)
 

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -149,6 +149,8 @@ gauge
 
         Sets the observation for ``label_pairs`` to ``num``.
 
+    ..  _metrics-api_reference-gauge_collect:
+
     ..  method:: collect(opts)
 
         :param table opts: table of collect options:
@@ -208,6 +210,8 @@ histogram
                                   observe new counter values.
                                   Note that both label names and values in ``label_pairs``
                                   are treated as strings.
+
+    ..  _metrics-api_reference-histogram_collect:
 
     ..  method:: collect(opts)
 
@@ -339,6 +343,8 @@ summary
                                   the observed value is added to each bucket.
                                   Note that both label names and values in ``label_pairs``
                                   are treated as strings.
+
+    ..  _metrics-api_reference-summary_collect:
 
     ..  method:: collect(opts)
 
@@ -508,6 +514,12 @@ Metrics functions
 
       * ``invoke_callbacks`` -- if ``true``, ``invoke_callbacks()`` is triggerred before actual collect.
       * ``default_only`` -- if ``true``, observations contain only default metrics (``metainfo.default = true``).
+      * ``extended_format`` -- if ``true``, collects extended format output from all collectors
+        (see :ref:`counter_obj:collect{extended_format = true} <metrics-api_reference-counter_collect>`,
+        :ref:`gauge_obj:collect{extended_format = true} <metrics-api_reference-gauge_collect>`,
+        :ref:`histogram_obj:collect{extended_format = true} <metrics-api_reference-histogram_collect>`,
+        :ref:`summary_obj:collect{extended_format = true} <metrics-api_reference-summary_collect>`)
+        and returns a map instead of an array.
 
 ..  class:: registry
 

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -51,18 +51,54 @@ counter
 
     ..  _metrics-api_reference-counter_collect:
 
-    ..  method:: collect()
+    ..  method:: collect(opts)
 
-        :return: Array of ``observation`` objects for a given counter.
+        :param table opts: table of collect options:
+
+          * ``extended_format`` -- use extended format in the output.
+
+        :return: Array of ``observation`` objects for a given counter (by default or if
+          ``extended format`` is ``false``). Otherwise returns a map with collector
+          description and structured observations.
 
         ..  code-block:: lua
 
+            counter_obj:collect{extended_format = false}
+
             {
-                label_pairs: table,          -- `label_pairs` key-value table
-                timestamp: ctype<uint64_t>,  -- current system time (in microseconds)
-                value: number,               -- current value
-                metric_name: string,         -- collector
+                -- an observation
+                {
+                    label_pairs: table,          -- `label_pairs` key-value table
+                    timestamp: ctype<uint64_t>,  -- observation time (in microseconds)
+                    value: number,               -- current value
+                    metric_name: string,         -- metric name
+                },
+                -- another observation...
             }
+
+        ..  code-block:: lua
+
+            counter_obj:collect{extended_format = true}
+
+            {
+                name: string, -- collector name
+                name_prefix: string, -- collector name prefix
+                kind: string, -- collector kind
+                help: string, -- collector help
+                metainfo: table, -- collector metainfo
+                timestamp: ctype<uint64_t>,  -- observation time (in microseconds)
+                observations = {
+                    [''] = { -- map of observations
+                        -- an observation
+                        key: string = {
+                            label_pairs: table,          -- `label_pairs` key-value table
+                            value: number,               -- current value
+                        },
+                        -- another observation...
+                    }
+                }
+            }
+
 
         :rtype: table
 
@@ -113,10 +149,13 @@ gauge
 
         Sets the observation for ``label_pairs`` to ``num``.
 
-    ..  method:: collect()
+    ..  method:: collect(opts)
 
-        Returns an array of ``observation`` objects for a given gauge.
-        For the description of ``observation``, see
+        :param table opts: table of collect options:
+
+          * ``extended_format`` -- use extended format in the output.
+
+        Returns format is the same as for
         :ref:`counter_obj:collect() <metrics-api_reference-counter_collect>`.
 
     ..  method:: remove(label_pairs)

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -340,11 +340,59 @@ summary
                                   Note that both label names and values in ``label_pairs``
                                   are treated as strings.
 
-    ..  method:: collect()
+    ..  method:: collect(opts)
 
-        Return a concatenation of ``counter_obj:collect()`` across all internal
-        counters of ``summary_obj``. For the description of ``observation``,
-        see :ref:`counter_obj:collect() <metrics-api_reference-counter_collect>`.
+        :param table opts: table of collect options:
+
+          * ``extended_format`` -- use extended format in the output.
+
+        :return: A concatenation of ``observation`` objects for a given counter (by default or if
+          ``extended format`` is ``false``). Otherwise returns a map with collector
+          description and structured observations.
+
+        ..  code-block:: lua
+
+            summary_obj:collect{extended_format = false}
+
+            {
+                -- an observation
+                {
+                    label_pairs: table,          -- `label_pairs` key-value table
+                    timestamp: ctype<uint64_t>,  -- observation time (in microseconds)
+                    value: number,               -- current value
+                    metric_name: string,         -- metric name
+                },
+                -- another observation...
+            }
+
+        ..  code-block:: lua
+
+            summary_obj:collect{extended_format = true}
+
+            {
+                name: string, -- collector name
+                name_suffix: string, -- collector name suffix
+                kind: string, -- collector kind
+                help: string, -- collector name
+                metainfo: table, -- collector metainfo
+                timestamp: ctype<uint64_t>,  -- observation time (in microseconds)
+                observations = {
+                    count = { -- map of count observations
+                        -- an observation
+                        key: string = {
+                            label_pairs: table,          -- `label_pairs` key-value table
+                            value: number,               -- current value
+                        },
+                        -- another observation...
+                    },
+                    sum = { -- map of sum observations
+                    },
+                    [''] = { -- map of quantile observations
+                    },
+                }
+            }
+
+
         If ``max_age_time`` and ``age_buckets_count`` are set, quantile observations
         are collected only from the head bucket in the sliding time window,
         not from every bucket. If no observations were recorded,

--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -60,6 +60,7 @@ build = {
         ['metrics.utils']                   = 'metrics/utils.lua',
         ['metrics.cfg']                     = 'metrics/cfg.lua',
         ['metrics.stash']                   = 'metrics/stash.lua',
+        ['metrics.string_utils']            = 'metrics/string_utils.lua',
         ['cartridge.roles.metrics']         = 'cartridge/roles/metrics.lua',
         ['cartridge.health']                = 'cartridge/health.lua',
     }

--- a/metrics/api.lua
+++ b/metrics/api.lua
@@ -3,6 +3,7 @@
 local checks = require('checks')
 
 local Registry = require('metrics.registry')
+local string_utils = require('metrics.string_utils')
 
 local Counter = require('metrics.collectors.counter')
 local Gauge = require('metrics.collectors.gauge')
@@ -116,10 +117,12 @@ local function set_global_labels(label_pairs)
     label_pairs = label_pairs or {}
 
     -- Verify label table
-    for k, _ in pairs(label_pairs) do
+    for k, v in pairs(label_pairs) do
         if type(k) ~= 'string' then
             error(("bad label key (string expected, got %s)"):format(type(k)))
         end
+        string_utils.check_symbols(k)
+        string_utils.check_symbols(v)
     end
 
     registry:set_labels(label_pairs)

--- a/metrics/collectors/shared.lua
+++ b/metrics/collectors/shared.lua
@@ -38,6 +38,7 @@ function Shared:new(name, help, metainfo)
 
     return setmetatable({
         name = name,
+        name_prefix = name:gsub('_total$', ''):gsub('_current$', ''),
         help = help or "",
         observations = {},
         label_pairs = {},

--- a/metrics/collectors/shared.lua
+++ b/metrics/collectors/shared.lua
@@ -2,6 +2,8 @@ local clock = require('clock')
 local fiber = require('fiber')
 local log = require('log')
 
+local string_utils = require('metrics.string_utils')
+
 local Shared = {}
 
 -- Create collector class with the list of instance methods copied from
@@ -19,6 +21,8 @@ function Shared:new_class(kind, method_names)
     for _, name in pairs(method_names) do
         methods[name] = self[name]
     end
+
+    string_utils.check_symbols(kind)
     local class = {kind = kind}
     class.__index = class
     return setmetatable(class, {__index = methods})
@@ -30,6 +34,8 @@ function Shared:new(name, help, metainfo)
     if not name then
         error("Name should be set for %s")
     end
+    string_utils.check_symbols(name)
+
     return setmetatable({
         name = name,
         help = help or "",
@@ -49,6 +55,8 @@ function Shared.make_key(label_pairs)
     end
     local parts = {}
     for k, v in pairs(label_pairs) do
+        string_utils.check_symbols(k)
+        string_utils.check_symbols(v)
         table.insert(parts, k .. '\t' .. v)
     end
     table.sort(parts)

--- a/metrics/string_utils.lua
+++ b/metrics/string_utils.lua
@@ -6,6 +6,15 @@ local function check_symbols(s)
     end
 end
 
+local function build_name(prefix, suffix)
+    if #suffix == 0 then
+        return prefix
+    end
+
+    return prefix .. '_' .. suffix
+end
+
 return {
     check_symbols = check_symbols,
+    build_name = build_name,
 }

--- a/metrics/string_utils.lua
+++ b/metrics/string_utils.lua
@@ -1,0 +1,11 @@
+local log = require('log')
+
+local function check_symbols(s)
+    if string.find(s, '%c') ~= nil then
+        log.error('Do not use control characters, this will raise an error in the future.')
+    end
+end
+
+return {
+    check_symbols = check_symbols,
+}

--- a/test/collectors/counter_test.lua
+++ b/test/collectors/counter_test.lua
@@ -135,3 +135,26 @@ for name, case in pairs(control_characters_cases) do
             'Do not use control characters, this will raise an error in the future.')
     end
 end
+
+g.test_collect_extended = function()
+    local c = metrics.counter('cnt', nil, {my_useful_info = 'here'})
+    c:inc(3, {mylabel = 'myvalue1'})
+    c:inc(2, {mylabel = 'myvalue2'})
+
+    local res = c:collect{extended_format = true}
+    t.assert_type(res, 'table')
+    t.assert_equals(res.name, c.name)
+    t.assert_equals(res.name_prefix, c.name_prefix)
+    t.assert_equals(res.kind, c.kind)
+    t.assert_equals(res.help, c.help)
+    t.assert_equals(res.metainfo, c.metainfo)
+    t.assert_gt(res.timestamp, 0)
+    t.assert_type(res.observations, 'table')
+    t.assert_type(res.observations[''], 'table')
+    t.assert_equals(utils.len(res.observations['']), 2)
+    for _, v in pairs(res.observations['']) do
+        t.assert_type(v.value, 'number')
+        t.assert_type(v.label_pairs, 'table')
+        t.assert_type(v.label_pairs['mylabel'], 'string')
+    end
+end

--- a/test/collectors/counter_test.lua
+++ b/test/collectors/counter_test.lua
@@ -1,6 +1,8 @@
 local t = require('luatest')
 local g = t.group()
 
+local luatest_capture = require('luatest.capture')
+
 local metrics = require('metrics')
 local utils = require('test.utils')
 
@@ -102,4 +104,34 @@ g.test_metainfo_immutable = function()
     local c = metrics.counter('cnt', nil, metainfo)
     metainfo['my_useful_info'] = 'there'
     t.assert_equals(c.metainfo, {my_useful_info = 'here'})
+end
+
+local control_characters_cases = {
+    in_name = function()
+        metrics.counter('cnt\tlab')
+    end,
+    in_observation_label_key = function()
+        local collector = metrics.counter('cnt')
+        collector:inc(1, {['lab\tval\tlab2'] = 'val2'})
+    end,
+    in_observation_label_value = function()
+        local collector = metrics.counter('cnt')
+        collector:inc(1, {lab = 'val\tlab2\tval2'})
+    end,
+}
+
+for name, case in pairs(control_characters_cases) do
+    g['test_control_characters_' .. name .. 'are_not_expected'] = function()
+        local capture = luatest_capture:new()
+        capture:enable()
+
+        case()
+
+        local stdout = utils.fflush_main_server_output(nil, capture)
+        capture:disable()
+
+        t.assert_str_contains(
+            stdout,
+            'Do not use control characters, this will raise an error in the future.')
+    end
 end

--- a/test/collectors/gauge_test.lua
+++ b/test/collectors/gauge_test.lua
@@ -122,3 +122,26 @@ for name, case in pairs(control_characters_cases) do
             'Do not use control characters, this will raise an error in the future.')
     end
 end
+
+g.test_collect_extended = function()
+    local c = metrics.gauge('gauge', nil, {my_useful_info = 'here'})
+    c:set(3, {mylabel = 'myvalue1'})
+    c:set(2, {mylabel = 'myvalue2'})
+
+    local res = c:collect{extended_format = true}
+    t.assert_type(res, 'table')
+    t.assert_equals(res.name, c.name)
+    t.assert_equals(res.name_prefix, c.name_prefix)
+    t.assert_equals(res.kind, c.kind)
+    t.assert_equals(res.help, c.help)
+    t.assert_equals(res.metainfo, c.metainfo)
+    t.assert_gt(res.timestamp, 0)
+    t.assert_type(res.observations, 'table')
+    t.assert_type(res.observations[''], 'table')
+    t.assert_equals(utils.len(res.observations['']), 2)
+    for _, v in pairs(res.observations['']) do
+        t.assert_type(v.value, 'number')
+        t.assert_type(v.label_pairs, 'table')
+        t.assert_type(v.label_pairs['mylabel'], 'string')
+    end
+end

--- a/test/collectors/gauge_test.lua
+++ b/test/collectors/gauge_test.lua
@@ -1,6 +1,8 @@
 local t = require('luatest')
 local g = t.group()
 
+local luatest_capture = require('luatest.capture')
+
 local metrics = require('metrics')
 local utils = require('test.utils')
 
@@ -89,4 +91,34 @@ g.test_metainfo_immutable = function()
     local c = metrics.gauge('gauge', nil, metainfo)
     metainfo['my_useful_info'] = 'there'
     t.assert_equals(c.metainfo, {my_useful_info = 'here'})
+end
+
+local control_characters_cases = {
+    in_name = function()
+        metrics.gauge('gauge\tlab')
+    end,
+    in_observation_label_key = function()
+        local collector = metrics.gauge('gauge')
+        collector:set(1, {['lab\tval\tlab2'] = 'val2'})
+    end,
+    in_observation_label_value = function()
+        local collector = metrics.gauge('gauge')
+        collector:set(1, {lab = 'val\tlab2\tval2'})
+    end,
+}
+
+for name, case in pairs(control_characters_cases) do
+    g['test_control_characters_' .. name .. 'are_not_expected'] = function()
+        local capture = luatest_capture:new()
+        capture:enable()
+
+        case()
+
+        local stdout = utils.fflush_main_server_output(nil, capture)
+        capture:disable()
+
+        t.assert_str_contains(
+            stdout,
+            'Do not use control characters, this will raise an error in the future.')
+    end
 end

--- a/test/collectors/histogram_test.lua
+++ b/test/collectors/histogram_test.lua
@@ -148,3 +148,42 @@ for name, case in pairs(control_characters_cases) do
             'Do not use control characters, this will raise an error in the future.')
     end
 end
+
+g.test_collect_extended = function()
+    local buckets = {2, 4}
+    local bucket_count = #buckets + 1
+    local c = metrics.histogram('histogram', nil, buckets, {my_useful_info = 'here'})
+    c:observe(3, {mylabel = 'myvalue1'})
+    c:observe(2, {mylabel = 'myvalue2'})
+
+    local res = c:collect{extended_format = true}
+    t.assert_type(res, 'table')
+    t.assert_equals(res.name, c.name)
+    t.assert_equals(res.name_suffix, c.name_suffix)
+    t.assert_equals(res.kind, c.kind)
+    t.assert_equals(res.help, c.help)
+    t.assert_equals(res.metainfo, c.metainfo)
+    t.assert_gt(res.timestamp, 0)
+    t.assert_type(res.observations, 'table')
+
+    t.assert_equals(utils.len(res.observations.bucket), 2 * bucket_count)
+    t.assert_equals(utils.len(res.observations.sum), 2)
+    t.assert_equals(utils.len(res.observations.count), 2)
+
+    for k, _ in pairs(res.observations.sum) do
+        t.assert_type(res.observations.count[k], 'table', "Each sum observation has corresponding count")
+    end
+
+    for _, section in ipairs({'count', 'sum', 'bucket'}) do
+        for _, v in pairs(res.observations[section]) do
+            t.assert_type(v.value, 'number')
+            t.assert_type(v.label_pairs, 'table')
+            t.assert_type(v.label_pairs['mylabel'], 'string')
+        end
+    end
+end
+
+g.test_internal_collect_observations = function()
+    local c = metrics.histogram('histogram', nil, {2, 4}, {my_useful_info = 'here'})
+    t.assert_error_msg_contains('Not supported', function() c:_collect_v2_observations() end)
+end

--- a/test/collectors/shared_test.lua
+++ b/test/collectors/shared_test.lua
@@ -113,3 +113,27 @@ for name, case in pairs(name_prefix_cases) do
         t.assert_equals(c.name_prefix, case.name_prefix)
     end
 end
+
+g.test_collect_extended = function()
+    local class = Shared:new_class('test_class', {'inc'})
+    local c = class:new('test', nil, {my_useful_info = 'here'})
+    c:inc(3, {mylabel = 'myvalue1'})
+    c:inc(2, {mylabel = 'myvalue2'})
+
+    local res = c:collect{extended_format = true}
+    t.assert_type(res, 'table')
+    t.assert_equals(res.name, c.name)
+    t.assert_equals(res.name_prefix, c.name_prefix)
+    t.assert_equals(res.kind, c.kind)
+    t.assert_equals(res.help, c.help)
+    t.assert_equals(res.metainfo, c.metainfo)
+    t.assert_gt(res.timestamp, 0)
+    t.assert_type(res.observations, 'table')
+    t.assert_type(res.observations[''], 'table')
+    t.assert_equals(utils.len(res.observations['']), 2)
+    for _, v in pairs(res.observations['']) do
+        t.assert_type(v.value, 'number')
+        t.assert_type(v.label_pairs, 'table')
+        t.assert_type(v.label_pairs['mylabel'], 'string')
+    end
+end

--- a/test/collectors/shared_test.lua
+++ b/test/collectors/shared_test.lua
@@ -82,3 +82,34 @@ for name, case in pairs(control_characters_cases) do
             'Do not use control characters, this will raise an error in the future.')
     end
 end
+
+local name_prefix_cases = {
+    without_suffix = {
+        name = 'my_metric',
+        name_prefix = 'my_metric',
+    },
+    with_current_suffix = {
+        name = 'my_metric_current',
+        name_prefix = 'my_metric',
+    },
+    with_total_suffix = {
+        name = 'my_metric_total',
+        name_prefix = 'my_metric',
+    },
+    with_current_not_as_suffix = {
+        name = 'electrical_current_value',
+        name_prefix = 'electrical_current_value',
+    },
+    with_total_not_as_suffix = {
+        name = 'sold_total_overdose_dvds',
+        name_prefix = 'sold_total_overdose_dvds',
+    },
+}
+
+for name, case in pairs(name_prefix_cases) do
+    g['test_name_prefix_if_' .. name] = function()
+        local class = Shared:new_class(case.name .. '_class', {'inc'})
+        local c = class:new(case.name)
+        t.assert_equals(c.name_prefix, case.name_prefix)
+    end
+end

--- a/test/collectors/shared_test.lua
+++ b/test/collectors/shared_test.lua
@@ -1,6 +1,8 @@
 local t = require('luatest')
 local g = t.group()
 
+local luatest_capture = require('luatest.capture')
+
 local utils = require('test.utils')
 local Shared = require('metrics.collectors.shared')
 
@@ -43,4 +45,40 @@ g.test_metainfo_immutable = function()
     local c = Shared:new('collector', nil, metainfo)
     metainfo['my_useful_info'] = 'there'
     t.assert_equals(c.metainfo, {my_useful_info = 'here'})
+end
+
+local control_characters_cases = {
+    in_kind = function()
+        Shared:new_class('test_class\tlab', {'inc'})
+    end,
+    in_name = function()
+        local class = Shared:new_class('test_class', {'inc'})
+        class:new('test\tlab')
+    end,
+    in_observation_label_key = function()
+        local class = Shared:new_class('test_class', {'inc'})
+        local collector = class:new('test')
+        collector:inc(1, {['lab\tval\tlab2'] = 'val2'})
+    end,
+    in_observation_label_value = function()
+        local class = Shared:new_class('test_class', {'inc'})
+        local collector = class:new('test')
+        collector:inc(1, {lab = 'val\tlab2\tval2'})
+    end,
+}
+
+for name, case in pairs(control_characters_cases) do
+    g['test_control_characters_' .. name .. 'are_not_expected'] = function()
+        local capture = luatest_capture:new()
+        capture:enable()
+
+        case()
+
+        local stdout = utils.fflush_main_server_output(nil, capture)
+        capture:disable()
+
+        t.assert_str_contains(
+            stdout,
+            'Do not use control characters, this will raise an error in the future.')
+    end
 end

--- a/test/plugins/prometheus_test.lua
+++ b/test/plugins/prometheus_test.lua
@@ -6,7 +6,7 @@ local t = require('luatest')
 local g = t.group('prometheus_plugin')
 
 local metrics = require('metrics')
-local http_handler = require('metrics.plugins.prometheus').collect_http
+local prometheus = require('metrics.plugins.prometheus')
 local utils = require('test.utils')
 
 g.before_all(function()
@@ -24,7 +24,7 @@ g.before_all(function()
     -- Enable default metrics collections
     metrics.enable_default_metrics()
 
-    g.prometheus_metrics = http_handler().body
+    g.prometheus_metrics = prometheus.collect_http().body
 end)
 
 g.after_each(function()
@@ -41,4 +41,34 @@ end
 g.test_cdata_handling = function()
     t.assert_str_contains(g.prometheus_metrics, 'tnt_space_bsize{name="random_space_for_prometheus",engine="memtx"} 0',
         'Plugin output serialize 0ULL as +Inf')
+end
+
+g.test_collect_and_serialize_preserves_format = function()
+    -- Prepare some data for all collector types.
+    metrics.cfg{include = 'all', exclude = {}, labels = {alias = 'router-3'}}
+
+    local c = metrics.counter('cnt', nil, {my_useful_info = 'here'})
+    c:inc(3, {mylabel = 'myvalue1'})
+    c:inc(2, {mylabel = 'myvalue2'})
+
+    c = metrics.gauge('gauge', nil, {my_useful_info = 'here'})
+    c:set(3, {mylabel = 'myvalue1'})
+    c:set(2, {mylabel = 'myvalue2'})
+
+    c = metrics.histogram('histogram', nil, {2, 4}, {my_useful_info = 'here'})
+    c:observe(3, {mylabel = 'myvalue1'})
+    c:observe(2, {mylabel = 'myvalue2'})
+
+    local output_v1 = prometheus.internal.collect_and_serialize_v1()
+    local output_v2 = prometheus.internal.collect_and_serialize_v2()
+
+    for line in output_v1:gmatch('[^\r\n]+') do
+        if line:startswith('#') then
+            t.assert_str_contains(output_v2, line)
+        else
+            local _, _, value_line_header = line:find('^(.*)%s')
+            -- Values of default metrics will be different for two different observations.
+            t.assert_str_contains(output_v2, value_line_header)
+        end
+    end
 end


### PR DESCRIPTION
This PR introduces new exhaustive export format on collect. It contains structured info on collectors which may be used on export and aggregation build. (Current `metrics.collect()` result is not enough on Prometheus export. `metrics.collect{extended_format = true}` is enough.) After this PR, export plugins will be based on extended format info.

See commit messages for more detailed info.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rst)
- [x] Rockspec and rpm spec

Part of tarantool/tarantool#7725
Part of tarantool/tarantool#7728
