### PR TITLE
plugin: flight recorder export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tools to compute metrics aggregates:
   - per second rate for counters;
   - min and max for gauges;
+  - average for histograms and summaries;
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - per second rate for counters;
   - min and max for gauges;
   - average for histograms and summaries;
+- plugin to export extended format data with aggregates to Flight recorder
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `metrics.collect()`;
 - tools to compute metrics aggregates:
   - per second rate for counters;
+  - min and max for gauges;
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `histogram_obj:collect()`;
   - `summary_obj:collect()`;
   - `metrics.collect()`;
-- tools to compute metrics aggregates
+- tools to compute metrics aggregates:
+  - per second rate for counters;
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `histogram_obj:collect()`;
   - `summary_obj:collect()`;
   - `metrics.collect()`;
+- tools to compute metrics aggregates
 
 ### Changed
 - Setup cartridge hotreload inside the role

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -614,7 +614,9 @@ Metrics functions
       * ``rate`` for counter collectors: per second rate of value change for the last
         two observations;
       * ``min`` for gauge collectors: minimal value for the history of observations;
-      * ``max`` for gauge collectors: maximal value for the history of observations.
+      * ``max`` for gauge collectors: maximal value for the history of observations;
+      * ``average`` for histogram and summary collectors: observations average value
+        (over all history of observations).
 
     :param table output_with_aggregates_prev: a previous result of this method call.
         Use ``nil`` if this is the first invokation. You may use

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -612,7 +612,9 @@ Metrics functions
     Supported aggregates:
 
       * ``rate`` for counter collectors: per second rate of value change for the last
-        two observations.
+        two observations;
+      * ``min`` for gauge collectors: minimal value for the history of observations;
+      * ``max`` for gauge collectors: maximal value for the history of observations.
 
     :param table output_with_aggregates_prev: a previous result of this method call.
         Use ``nil`` if this is the first invokation. You may use

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -609,6 +609,11 @@ Metrics functions
 
     API to extend metrics output with various metrics based on their kind.
 
+    Supported aggregates:
+
+      * ``rate`` for counter collectors: per second rate of value change for the last
+        two observations.
+
     :param table output_with_aggregates_prev: a previous result of this method call.
         Use ``nil`` if this is the first invokation. You may use
         ``metrics.collect{extended_format = true}`` result instead, but in this case

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -605,6 +605,24 @@ Metrics functions
     If you're using one of the default exporters,
     ``invoke_callbacks()`` will be called by the exporter.
 
+..  function:: compute_aggregates(output_with_aggregates_prev, output, kind_rules)
+
+    API to extend metrics output with various metrics based on their kind.
+
+    :param table output_with_aggregates_prev: a previous result of this method call.
+        Use ``nil`` if this is the first invokation. You may use
+        ``metrics.collect{extended_format = true}`` result instead, but in this case
+        result will ignore some historical info.
+
+    :param table output: result of ``metrics.collect{extended_format = true}``.
+
+    :param table kind_rules: table of computation rules applied to all obervations based
+        on collector kind. Format is as follows:
+        ``{ counter = { 'rate' }, gauge = { 'min', 'max' }}``. Computes all supported
+        aggregates by default.
+
+    :return: Table with all ``output`` entries and their aggregates.
+
 ..  _metrics-api_reference-role_functions:
 
 Metrics role API

--- a/doc/monitoring/plugins.rst
+++ b/doc/monitoring/plugins.rst
@@ -199,6 +199,54 @@ Use the JSON plugin with Tarantool ``http.server`` as follows:
         end
     )
 
+Flight recorder
+~~~~~~~~~~~~~~~
+
+Usage
+^^^^^
+
+Import the plugin:
+
+..  code-block:: lua
+
+    local flight_recorder_exporter = require('metrics.plugins.flight_recorder')
+
+..  module:: metrics.plugins.flight_recorder
+
+..  function:: export()
+
+    :return: extended format output with aggregates
+
+        ..  code-block:: yaml
+
+            - tnt_net_per_thread_connections_mingauge:
+                name: tnt_net_per_thread_connections_min
+                name_prefix: tnt_net_per_thread_connections
+                kind: gauge
+                metainfo:
+                  aggregate: true
+                  default: true
+                timestamp: 1676478112824745
+                observations:
+                  '':
+                    "thread\t1":
+                      label_pairs:
+                        thread: '1'
+                      value: 0
+            ...
+
+..  function:: plain_format(output)
+
+    :return: human-readable form of output
+
+        ..  code-block:: text
+
+            tnt_info_memory_lua_max{alias=router-4} 10237204
+            tnt_info_memory_lua_min{alias=router-4} 1921790
+            tnt_info_memory_lua{alias=router-4} 2733335
+            tnt_info_uptime{alias=router-4} 1052
+            ...
+
 .. _metrics-plugins-custom:
 
 Creating custom plugins

--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -61,6 +61,7 @@ build = {
         ['metrics.cfg']                     = 'metrics/cfg.lua',
         ['metrics.stash']                   = 'metrics/stash.lua',
         ['metrics.string_utils']            = 'metrics/string_utils.lua',
+        ['metrics.aggregates']              = 'metrics/aggregates.lua',
         ['cartridge.roles.metrics']         = 'cartridge/roles/metrics.lua',
         ['cartridge.health']                = 'cartridge/health.lua',
     }

--- a/metrics-scm-1.rockspec
+++ b/metrics-scm-1.rockspec
@@ -36,6 +36,7 @@ build = {
         ['metrics.plugins.graphite']        = 'metrics/plugins/graphite.lua',
         ['metrics.plugins.prometheus']      = 'metrics/plugins/prometheus.lua',
         ['metrics.plugins.json']            = 'metrics/plugins/json.lua',
+        ['metrics.plugins.flight_recorder'] = 'metrics/plugins/flight_recorder.lua',
         ['metrics.tarantool']               = 'metrics/tarantool.lua',
         ['metrics.tarantool.fibers']        = 'metrics/tarantool/fibers.lua',
         ['metrics.tarantool.info']          = 'metrics/tarantool/info.lua',

--- a/metrics/aggregates.lua
+++ b/metrics/aggregates.lua
@@ -1,12 +1,19 @@
 local string_utils = require('metrics.string_utils')
 local Counter = require('metrics.collectors.counter')
 local Gauge = require('metrics.collectors.gauge')
+local Histogram = require('metrics.collectors.histogram')
+local Summary = require('metrics.collectors.summary')
+
+-- Otherwise we need to implement different average processors.
+assert(Histogram.SUM_SUFFIX == Summary.SUM_SUFFIX)
+assert(Histogram.COUNT_SUFFIX == Summary.COUNT_SUFFIX)
 
 local mksec_in_sec = 1e6
 
 local RATE_SUFFIX = 'per_second'
 local MIN_SUFFIX = 'min'
 local MAX_SUFFIX = 'max'
+local AVERAGE_SUFFIX = 'average'
 
 local function compute_rate_value(time_delta, obs_prev, obs)
     if obs_prev == nil then
@@ -133,16 +140,68 @@ local function compute_gauge_max(output_with_aggregates_prev, output, coll_key, 
                                   math.max, MAX_SUFFIX, "Maximum of ")
 end
 
+local function compute_average_value(sum_obs, count_obs)
+    -- For each sum there should be count, otherwise info is malformed.
+    if sum_obs == nil then
+        return nil
+    end
+
+    if count_obs.value == 0 then
+        return {
+            label_pairs = count_obs.label_pairs,
+            value = 0,
+        }
+    end
+
+    return {
+        label_pairs = count_obs.label_pairs,
+        -- Force to float division instead of possible cdata integer division.
+        value = tonumber(sum_obs.value) / tonumber(count_obs.value),
+    }
+end
+
+local function compute_collector_average(_, output, _, coll_obs)
+    local name = string_utils.build_name(coll_obs.name_prefix, AVERAGE_SUFFIX)
+    local kind = Gauge.kind
+    local registry_key = string_utils.build_registry_key(name, kind)
+
+    if output[registry_key] ~= nil then
+        -- If, for any reason, registry collision had happenned,
+        -- we assume that there is already an aggregate metric with the
+        -- similar meaning.
+        return registry_key, output[registry_key]
+    end
+
+    local values = {}
+
+    for key, count_obs in pairs(coll_obs.observations[Histogram.COUNT_SUFFIX]) do
+        local sum_obs = coll_obs.observations[Histogram.SUM_SUFFIX][key]
+        values[key] = compute_average_value(sum_obs, count_obs)
+    end
+
+    return registry_key, {
+        name = name,
+        name_prefix = coll_obs.name_prefix,
+        help = "Average value (over all time) of " .. coll_obs.name,
+        kind = kind,
+        metainfo = coll_obs.metainfo,
+        timestamp = coll_obs.timestamp,
+        observations = {[''] = values}
+    }
+end
 
 local default_kind_rules = {
     [Counter.kind] = { 'rate' },
     [Gauge.kind] = { 'min', 'max' },
+    [Histogram.kind] = { 'average' },
+    [Summary.kind] = { 'average' },
 }
 
 local rule_processors = {
     rate = compute_counter_rate,
     min = compute_gauge_min,
     max = compute_gauge_max,
+    average = compute_collector_average,
 }
 
 local function compute(output_with_aggregates_prev, output, kind_rules)

--- a/metrics/aggregates.lua
+++ b/metrics/aggregates.lua
@@ -1,0 +1,29 @@
+local default_kind_rules = {}
+
+local rule_processors = {}
+
+local function compute(output_with_aggregates_prev, output, kind_rules)
+    output_with_aggregates_prev = output_with_aggregates_prev or {}
+    kind_rules = kind_rules or default_kind_rules
+
+    -- Iterating through table and adding new keys may result in skipping some keys.
+    local output_with_aggregates = table.deepcopy(output)
+
+    for coll_key, coll_obs in pairs(output) do
+        local coll_rules = kind_rules[coll_obs.kind] or {}
+        for _, rule in ipairs(coll_rules) do
+            if rule_processors[rule] == nil then
+                error(("Unknown rule %q"):format(rule))
+            end
+
+            local k, v = rule_processors[rule](output_with_aggregates_prev, output, coll_key, coll_obs)
+            output_with_aggregates[k] = v
+        end
+    end
+
+    return output_with_aggregates
+end
+
+return {
+    compute = compute,
+}

--- a/metrics/aggregates.lua
+++ b/metrics/aggregates.lua
@@ -1,6 +1,79 @@
-local default_kind_rules = {}
+local string_utils = require('metrics.string_utils')
+local Counter = require('metrics.collectors.counter')
+local Gauge = require('metrics.collectors.gauge')
 
-local rule_processors = {}
+local mksec_in_sec = 1e6
+
+local RATE_SUFFIX = 'per_second'
+
+local function compute_rate_value(time_delta, obs_prev, obs)
+    if obs_prev == nil then
+        return nil
+    end
+
+    return {
+        label_pairs = obs.label_pairs,
+        value = tonumber(obs.value - obs_prev.value) / (time_delta / mksec_in_sec)
+    }
+end
+
+local function compute_counter_rate(output_with_aggregates_prev, output, coll_key, coll_obs)
+    local name = string_utils.build_name(coll_obs.name_prefix, RATE_SUFFIX)
+    local kind = Gauge.kind -- Derivative of monotonic is not monotonic.
+    local registry_key = string_utils.build_registry_key(name, kind)
+
+    if output[registry_key] ~= nil then
+        -- If, for any reason, registry collision had happenned,
+        -- we assume that there is already an aggregate metric with the
+        -- similar meaning.
+        return registry_key, output[registry_key]
+    end
+
+    local prev_coll_obs = output_with_aggregates_prev[coll_key]
+
+    if prev_coll_obs == nil then
+        return registry_key, nil
+    end
+
+
+    -- ULL subtraction on older Tarantools yields big ULL.
+    if coll_obs.timestamp <= prev_coll_obs.timestamp then
+        return registry_key, nil
+    end
+
+    -- tonumber to work with float deltas instead of cdata integers.
+    local time_delta = tonumber(coll_obs.timestamp - prev_coll_obs.timestamp)
+
+    if time_delta <= 0 then
+        return registry_key, nil
+    end
+
+    local values = {}
+
+    for key, obs in pairs(coll_obs.observations['']) do
+        local obs_prev = prev_coll_obs.observations[''][key]
+        values[key] = compute_rate_value(time_delta, obs_prev, obs)
+    end
+
+    return registry_key, {
+        name = name,
+        name_prefix = coll_obs.name_prefix,
+        help = "Average per second rate of change of " .. coll_obs.name,
+        kind = kind,
+        metainfo = coll_obs.metainfo,
+        timestamp = coll_obs.timestamp,
+        observations = {[''] = values}
+    }
+end
+
+
+local default_kind_rules = {
+    [Counter.kind] = { 'rate' },
+}
+
+local rule_processors = {
+    rate = compute_counter_rate,
+}
 
 local function compute(output_with_aggregates_prev, output, kind_rules)
     output_with_aggregates_prev = output_with_aggregates_prev or {}

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -5,6 +5,7 @@ local const = require('metrics.const')
 local cfg = require('metrics.cfg')
 local http_middleware = require('metrics.http_middleware')
 local tarantool = require('metrics.tarantool')
+local aggregates = require('metrics.aggregates')
 
 local VERSION = '0.16.0-scm'
 
@@ -29,6 +30,7 @@ return {
     cfg = cfg.cfg,
     http_middleware = http_middleware,
     collect = api.collect,
+    compute_aggregates = aggregates.compute,
     VERSION = VERSION,
     _VERSION = VERSION,
 }

--- a/metrics/plugins/flight_recorder.lua
+++ b/metrics/plugins/flight_recorder.lua
@@ -1,0 +1,42 @@
+local metrics = require('metrics')
+local stash = require('metrics.stash')
+local string_utils = require('metrics.string_utils')
+
+local data_stash = stash.get('flight_recorder')
+
+local function export()
+    local output = metrics.collect{invoke_callbacks = true, extended_format = true}
+    local output_with_aggregates = metrics.compute_aggregates(
+        data_stash.output_with_aggregates_prev, output)
+    data_stash.output_with_aggregates_prev = output_with_aggregates
+    return output_with_aggregates
+end
+
+local function plain_format(output)
+    local result = {}
+    for _, coll_obs in pairs(output) do
+        for group_name, obs_group in pairs(coll_obs.observations) do
+            local metric_name = string_utils.build_name(coll_obs.name, group_name)
+            for _, obs in pairs(obs_group) do
+                local parts = {}
+                for k, v in pairs(obs.label_pairs) do
+                    table.insert(parts, k .. '=' .. v)
+                end
+                table.sort(parts)
+                table.insert(result, string.format('%s{%s} %s',
+                    metric_name,
+                    table.concat(parts, ','),
+                    obs.value
+                ))
+            end
+        end
+    end
+
+    table.sort(result)
+    return table.concat(result, '\n')
+end
+
+return {
+    export = export,
+    plain_format = plain_format,
+}

--- a/metrics/registry.lua
+++ b/metrics/registry.lua
@@ -1,3 +1,5 @@
+local string_utils = require('metrics.string_utils')
+
 local Registry = {}
 Registry.__index = Registry
 
@@ -15,7 +17,7 @@ function Registry:clear()
 end
 
 function Registry:find(kind, name)
-    return self.collectors[name .. kind]
+    return self.collectors[string_utils.build_registry_key(name, kind)]
 end
 
 function Registry:find_or_create(class, name, ...)
@@ -34,12 +36,12 @@ function Registry:register(collector)
         error('Already registered')
     end
     collector:set_registry(self)
-    self.collectors[collector.name .. collector.kind] = collector
+    self.collectors[string_utils.build_registry_key(collector.name, collector.kind)] = collector
     return collector
 end
 
 function Registry:unregister(collector)
-    self.collectors[collector.name .. collector.kind] = nil
+    self.collectors[string_utils.build_registry_key(collector.name, collector.kind)] = nil
 end
 
 function Registry:invoke_callbacks()

--- a/metrics/stash.lua
+++ b/metrics/stash.lua
@@ -7,9 +7,13 @@ local stash = {}
 -- @tfield string cfg
 --  Stash for metrics module configuration.
 --
+-- @tfield string flight_recorder
+--  Stash for flight recorder plugin data.
+--
 stash.name = {
     cfg = '__metrics_cfg',
-    cfg_internal = '__metrics_cfg_internal'
+    cfg_internal = '__metrics_cfg_internal',
+    flight_recorder = '__flight_recorder',
 }
 
 --- Setup Tarantool Cartridge reload.

--- a/metrics/string_utils.lua
+++ b/metrics/string_utils.lua
@@ -14,7 +14,12 @@ local function build_name(prefix, suffix)
     return prefix .. '_' .. suffix
 end
 
+local function build_registry_key(name, kind)
+    return name .. kind
+end
+
 return {
     check_symbols = check_symbols,
     build_name = build_name,
+    build_registry_key = build_registry_key,
 }

--- a/test/aggregates_test.lua
+++ b/test/aggregates_test.lua
@@ -1,0 +1,49 @@
+local t = require('luatest')
+
+local g = t.group('metrics_aggregates')
+
+local metrics = require('metrics')
+
+local function get_counter_example(timestamp, value1, value2)
+    local res = {
+        lj_gc_steps_propagate_totalcounter = {
+            name = 'lj_gc_steps_propagate_total',
+            name_prefix = 'lj_gc_steps_propagate',
+            kind = 'counter',
+            help = 'Total count of incremental GC steps (propagate state)',
+            metainfo = { default = true },
+            timestamp = timestamp,
+            observations = { [''] = {} },
+        }
+    }
+
+    if value1 ~= nil then
+        res['lj_gc_steps_propagate_totalcounter'].observations[''][''] = {
+            label_pairs = { alias = 'router' },
+            value = value1,
+        }
+    end
+
+    if value2 ~= nil then
+        res['lj_gc_steps_propagate_totalcounter'].observations['']['source\tvinyl_procedures'] = {
+            label_pairs = { alias = 'router', source = 'vinyl_procedures' },
+            value = value2,
+        }
+    end
+
+    return res
+end
+
+g.test_unknown_rule = function()
+    local output = get_counter_example(1676364616294847ULL, 14148, 3204)
+
+    local opts = { counter = { 'per_hour_rate' }}
+    t.assert_error_msg_contains('Unknown rule "per_hour_rate"',
+        metrics.compute_aggregates, nil, output, opts)
+end
+
+g.test_no_rules = function()
+    local output = get_counter_example(1676364616294847ULL, 14148, 3204)
+    local original_output = table.deepcopy(output)
+    t.assert_equals(metrics.compute_aggregates(nil, output), original_output)
+end

--- a/test/aggregates_test.lua
+++ b/test/aggregates_test.lua
@@ -3,6 +3,7 @@ local t = require('luatest')
 local g = t.group('metrics_aggregates')
 
 local metrics = require('metrics')
+local utils = require('test.utils')
 
 local function get_counter_example(timestamp, value1, value2)
     local res = {
@@ -46,4 +47,85 @@ g.test_no_rules = function()
     local output = get_counter_example(1676364616294847ULL, 14148, 3204)
     local original_output = table.deepcopy(output)
     t.assert_equals(metrics.compute_aggregates(nil, output), original_output)
+end
+
+g.test_counter_rate_no_previous_data = function()
+    local output = get_counter_example(1676364616294847ULL, 14148, 3204)
+
+    local output_with_aggregates = metrics.compute_aggregates(nil, output)
+    t.assert_equals(utils.len(output_with_aggregates), 1,
+        "No rate computed for a single observation")
+end
+
+g.test_counter_rate = function()
+    local output_1 = get_counter_example(1676364616294847ULL, 14148, 3204)
+    local output_2 = get_counter_example(1676364616294847ULL + 100 * 1e6, 14148 + 200, 3204 + 50)
+
+    local output_with_aggregates_1 = metrics.compute_aggregates(nil, output_1)
+    local output_with_aggregates_2 = metrics.compute_aggregates(output_with_aggregates_1, output_2)
+
+    t.assert_equals(utils.len(output_with_aggregates_2), 2, "Rate computed")
+
+    local rate_obs = output_with_aggregates_2['lj_gc_steps_propagate_per_secondgauge']
+    t.assert_not_equals(rate_obs, nil, "Rate computed")
+    t.assert_equals(rate_obs.name, 'lj_gc_steps_propagate_per_second')
+    t.assert_equals(rate_obs.name_prefix, 'lj_gc_steps_propagate')
+    t.assert_equals(rate_obs.kind, 'gauge')
+    t.assert_equals(rate_obs.help, 'Average per second rate of change of lj_gc_steps_propagate_total')
+    t.assert_equals(rate_obs.metainfo.default, true)
+    t.assert_equals(rate_obs.timestamp, 1676364616294847ULL + 100 * 1e6)
+    t.assert_equals(rate_obs.observations[''][''].label_pairs, { alias = 'router' })
+    t.assert_almost_equals(rate_obs.observations[''][''].value, 200 / 100)
+    t.assert_equals(rate_obs.observations['']['source\tvinyl_procedures'].label_pairs,
+        { alias = 'router', source = 'vinyl_procedures' })
+    t.assert_almost_equals(rate_obs.observations['']['source\tvinyl_procedures'].value, 50 / 100)
+end
+
+g.test_counter_rate_new_label = function()
+    local output_1 = get_counter_example(1676364616294847ULL, 14148, nil)
+    local output_2 = get_counter_example(1676364616294847ULL + 100 * 1e6, 14148 + 200, 3204)
+
+    local output_with_aggregates_1 = metrics.compute_aggregates(nil, output_1)
+    local output_with_aggregates_2 = metrics.compute_aggregates(output_with_aggregates_1, output_2)
+
+    t.assert_equals(utils.len(output_with_aggregates_2), 2, "Rate computed")
+
+    local rate_obs = output_with_aggregates_2['lj_gc_steps_propagate_per_secondgauge']
+    t.assert_not_equals(rate_obs, nil, "Rate computed")
+    t.assert_not_equals(rate_obs.observations[''][''], nil)
+    t.assert_equals(rate_obs.observations['']['source\tvinyl_procedures'], nil)
+end
+
+g.test_counter_rate_wrong_timeline = function()
+    local output_1 = get_counter_example(1676364616294847ULL, 14148, 3204)
+    local output_2 = get_counter_example(1676364616294847ULL + 100 * 1e6, 14148 + 200, 3204 + 50)
+
+    local output_with_aggregates_2 = metrics.compute_aggregates(nil, output_2)
+    local output_with_aggregates_1 = metrics.compute_aggregates(output_with_aggregates_2, output_1)
+
+    t.assert_equals(utils.len(output_with_aggregates_1), 1,
+        "No rate computed for reverse observations timeline")
+end
+
+g.test_counter_rate_too_high_collect_rate = function()
+    local output_1 = get_counter_example(1676364616294847ULL, 14148, 3204)
+    local output_2 = get_counter_example(1676364616294847ULL, 14148 + 200, 3204 + 50)
+
+    local output_with_aggregates_1 = metrics.compute_aggregates(nil, output_1)
+    local output_with_aggregates_2 = metrics.compute_aggregates(output_with_aggregates_1, output_2)
+
+    t.assert_equals(utils.len(output_with_aggregates_2), 1,
+        "No rate computed if two observations are for the same time")
+end
+
+g.test_counter_rate_disabled = function()
+    local output_1 = get_counter_example(1676364616294847ULL, 14148, 3204)
+    local output_2 = get_counter_example(1676364616294847ULL + 100 * 1e6, 14148 + 200, 3204 + 50)
+
+    local opts = { counter = {} }
+    local output_with_aggregates_1 = metrics.compute_aggregates(nil, output_1, opts)
+    local output_with_aggregates_2 = metrics.compute_aggregates(output_with_aggregates_1, output_2, opts)
+
+    t.assert_equals(utils.len(output_with_aggregates_2), 1,
+        "No rate computed due to options")
 end

--- a/test/plugins/flight_recorder_test.lua
+++ b/test/plugins/flight_recorder_test.lua
@@ -1,0 +1,81 @@
+#!/usr/bin/env tarantool
+
+local t = require('luatest')
+local g = t.group('flight_recorder_plugin')
+
+local flight_recorder_exporter = require('metrics.plugins.flight_recorder')
+local metrics = require('metrics')
+local metrics_stash = require('metrics.stash')
+local utils = require('test.utils')
+
+g.before_all(utils.init)
+
+g.before_each(function()
+    metrics_stash.get('flight_recorder').output_with_aggregates_prev = nil
+    metrics.clear()
+    metrics.cfg{include = 'all', exclude = {}, labels = {}}
+end)
+
+g.test_exporter = function()
+    metrics.counter('counter_test_total'):inc(1)
+    metrics.gauge('gauge_test'):set(1)
+    metrics.histogram('histogram_test'):observe(1)
+    metrics.summary('summary_test'):observe(1)
+
+    local output_non_plugin = metrics.collect{invoke_callbacks = true, extended_format = true}
+
+    local output_exporter_1 = flight_recorder_exporter.export()
+    local output_exporter_2 = flight_recorder_exporter.export()
+    local output_exporter_3 = flight_recorder_exporter.export()
+
+    for key, _ in pairs(output_non_plugin) do
+        t.assert_type(output_exporter_1[key], 'table',
+            'Default metric observation presents in exporter output')
+    end
+
+    t.assert_gt(utils.len(output_exporter_1), utils.len(output_non_plugin),
+        'Exporter observations is extended with aggregates (min, max, average)')
+
+    t.assert_type(output_exporter_1['gauge_test_mingauge'], 'table',
+        'Exporter observations is extended with min aggregates')
+    t.assert_type(output_exporter_1['gauge_test_maxgauge'], 'table',
+        'Exporter observations is extended with max aggregates')
+    t.assert_type(output_exporter_1['histogram_test_averagegauge'], 'table',
+        'Exporter observations is extended with histogram average aggregates')
+    t.assert_type(output_exporter_1['summary_test_averagegauge'], 'table',
+        'Exporter observations is extended with summary average aggregates')
+
+    t.assert_gt(utils.len(output_exporter_2), utils.len(output_exporter_1),
+        'Exporter observations is extended with aggregates (rate)')
+
+    t.assert_type(output_exporter_2['counter_test_per_secondgauge'], 'table',
+        'Exporter observations is extended with rate aggregates')
+
+    t.assert_equals(utils.len(output_exporter_3), utils.len(output_exporter_2),
+        'Exporter observations contains the same set of aggregates after second collect')
+end
+
+g.test_plain_format = function()
+    metrics.cfg{labels = {alias = 'router-4'}}
+
+    metrics.counter('counter_test_total'):inc(1, {label = 'value'})
+    metrics.gauge('gauge_test'):set(2, {label = 'value'})
+    metrics.histogram('histogram_test'):observe(3, {label = 'value'})
+    metrics.summary('summary_test'):observe(4, {label = 'value'})
+
+    local output = flight_recorder_exporter.export()
+
+    local plain_format_output = flight_recorder_exporter.plain_format(output)
+    t.assert_str_contains(plain_format_output,
+        'counter_test_total{alias=router-4,label=value} 1')
+    t.assert_str_contains(plain_format_output,
+        'gauge_test{alias=router-4,label=value} 2')
+    t.assert_str_contains(plain_format_output,
+        'histogram_test_count{alias=router-4,label=value} 1')
+    t.assert_str_contains(plain_format_output,
+        'histogram_test_sum{alias=router-4,label=value} 3')
+    t.assert_str_contains(plain_format_output,
+        'summary_test_count{alias=router-4,label=value} 1')
+    t.assert_str_contains(plain_format_output,
+        'summary_test_sum{alias=router-4,label=value} 4')
+end


### PR DESCRIPTION
This PR gets advantage of the new export format introduced in #436 and provides new API to compute aggregates like per second rate, min, max and average. New handles used to build Flight recorder exporter plugin. See commits for more detailed info.

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rst)
- [x] Rockspec and rpm spec

Part of tarantool/tarantool#7725
Part of tarantool/tarantool#7728
