### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.17.0] - 2023-03-23
 ### Added
 - `metrics.cfg{}` -- a single entrypoint to setup the module:
   - `include` and `exclude` options with the same effect as in

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -305,7 +305,7 @@ Metrics functions
 
 ..  function:: cfg([config])
 
-    Entrypoint to setup the module.
+    Entrypoint to setup the module. Since 0.17.0.
 
     :param table config: module configuration options:
 

--- a/metrics/version.lua
+++ b/metrics/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '0.16.0'
+return '0.17.0'


### PR DESCRIPTION
### Overview

This release introduces a single entrypoint to setup the module:
`metrics.cfg`, as well as several updates due to package embedding
to the core Tarantool (available only in master now).

### Breaking changes

This release should not break existing behaviour.

### Added
- `metrics.cfg{}` -- a single entrypoint to setup the module:
  - `include` and `exclude` options with the same effect as in
    `enable_default_metrics(include, exclude)` (but its deprecated
    features already disabled);
  - `labels` options with the same effect as `set_global_labels(labels)`;
  - values and effect (like default metrics callbacks) are preserved
    between reloads;
  - does not deal with external features like cartridge HTTP setup
- Versioning support through `require('metrics')._VERSION`

### Changed
- Setup cartridge hotreload inside the role
- Extend `enable_default_metrics()` API:
  - `'all'` and `'none'` options for `include` argument,
  - simultaneous `include` and `exclude` arguments
    (`exclude` has higher priority)
- Build rock with cmake
- Override built-in metrics, if installed

### Deprecated
- Passing nonexistent metrics to `enable_default_metrics()`
- Using `{}` as `include` in `enable_default_metrics()`
  to enable all metrics
- Versioning support through `require('metrics').VERSION`