### PR TITLE
Added function `set_is_health_handler` + refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ prometheus-input
 doc/.doctrees/
 doc/output/
 doc/locale/en/
+.idea/
 
 *.lua.c
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Don't export self replication status.
+- Function ``set_is_health_handler`` has been added to role ``cartridge.roles.metrics``,
+  allowing you to set your own handle to check health
+  [tarantool/cartridge#2097](https://github.com/tarantool/cartridge/issues/2097).
+  Main case - customizing the healthcheck response format.
 
 ## [0.17.0] - 2023-03-23
 ### Added

--- a/cartridge/roles/metrics.lua
+++ b/cartridge/roles/metrics.lua
@@ -4,6 +4,7 @@ local hotreload_supported, hotreload = pcall(require, 'cartridge.hotreload')
 local metrics = require('metrics')
 local metrics_stash = require('metrics.stash')
 local log = require('log')
+local health = require('cartridge.health')
 
 local metrics_vars = require('cartridge.vars').new('metrics_vars')
 metrics_vars:new('current_paths', {})
@@ -21,10 +22,7 @@ local handlers = {
         local http_handler = require('metrics.plugins.prometheus').collect_http
         return http_handler(...)
     end,
-    ['health'] = function(...)
-        local http_handler = require('cartridge.health').is_healthy
-        return http_handler(...)
-    end,
+    ['health'] = health.default_is_healthy_handler,
 }
 
 local function set_labels(custom_labels)
@@ -240,6 +238,17 @@ local function stop()
     metrics_vars.custom_labels = {}
 end
 
+local function set_is_health_handler(new_handler)
+    handlers['health'] = new_handler or health.default_is_healthy_handler
+
+    local paths = table.copy(metrics_vars.current_paths)
+    for path, _ in pairs(metrics_vars.current_paths) do
+        metrics_vars.current_paths[path] = ''
+    end
+
+    apply_routes(paths)
+end
+
 return setmetatable({
     role_name = 'metrics',
     permanent = true,
@@ -249,4 +258,5 @@ return setmetatable({
     apply_config = apply_config,
     set_export = set_export,
     set_default_labels = set_default_labels,
+    set_is_health_handler = set_is_health_handler,
 }, { __index = metrics })

--- a/doc/monitoring/getting_started.rst
+++ b/doc/monitoring/getting_started.rst
@@ -93,6 +93,23 @@ which the load balancer can use to check the current state of any Tarantool inst
 If the instance is ready to accept the load, it will return a response with a 200 status code,
 and if not, with a 500 status code.
 
+If you need a custom healthckeck response, then you will need to replace the default handler with your own. Example:
+
+.. code-block:: lua
+
+	local metrics = require('cartridge.roles.metrics')
+
+	metrics.set_is_health_handler(function(req)
+		local health = require('cartridge.health')
+		local resp = req:render{
+			json = {
+				my_healthcheck_format = health.is_healthy()
+			}
+		}
+		resp.status = 200
+		return resp
+	end)
+
 .. _monitoring-getting_started-cartridge_role:
 
 Cartridge role


### PR DESCRIPTION
See problem description [here](https://github.com/tarantool/cartridge-metrics-role/issues/4)
I propose to give the user the function of setting their own handler to check health.

``` lua
local metrics = require('cartridge.roles.metrics')
metrics.set_custom_is_health_handler(function(req)
    local health = require('cartridge.health')
    local resp = req:render{
        json = {
            my_healthcheck_format = health.is_healthy()
        }
    }
    resp.status = 200
    return resp
end)
```

# Changes
- `metrics.lua` - added function `set_custom_health_handler`, subj
- `health.lua` - divided one function `is_healthy` to three: `is_healthy`, `is_healthy_handler`, `member_is_healthy` - the content of each of which is consistent with the title
- `getting_started.rst` - added description
- `.gitignore` - added ignore IDE JetBrains files
- `cartridge_health_test.lua` - added test
- `CHANGELOG.md` - added change information.

# Checklist
- [x] Tests
- [x] Changelog
- [x] Documentation

# Links
Close 
- https://github.com/tarantool/cartridge-metrics-role/issues/4
