### PR TITLE
test: workaround LUA_PATH only for repo tests

### DIFF
--- a/test/cfg_test.lua
+++ b/test/cfg_test.lua
@@ -1,20 +1,14 @@
 local t = require('luatest')
 local group = t.group('cfg')
 
-local fio = require('fio')
-
 local metrics = require('metrics')
 local utils = require('test.utils')
-
-local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.helper'))))
 
 local function create_server(g)
     g.server = t.Server:new({
         alias = 'myserver',
         env = {
-            LUA_PATH = root .. '/?.lua;' ..
-                root .. '/?/init.lua;' ..
-                root .. '/.rocks/share/tarantool/?.lua'
+            LUA_PATH = utils.LUA_PATH
         }
     })
     g.server:start{wait_until_ready = true}

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -6,6 +6,13 @@ require('test.rock_utils').assert_nonbuiltin('metrics')
 
 local fio = require('fio')
 local utils = require('test.utils')
+
+local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.utils'))))
+
+package.loaded['test.utils'].LUA_PATH = root .. '/?.lua;' ..
+    root .. '/?/init.lua;' ..
+    root .. '/.rocks/share/tarantool/?.lua'
+
 local t = require('luatest')
 local ok, cartridge_helpers = pcall(require, 'cartridge.test-helpers')
 if not ok then

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -137,4 +137,9 @@ function utils.fflush_main_server_output(server, capture)
     return captured
 end
 
+
+-- Empty by default. Empty LUA_PATH satisfies built-in package tests.
+-- For tarantool/metrics, LUA_PATH is set up through test.helper
+utils.LUA_PATH = nil
+
 return utils


### PR DESCRIPTION
luatest implicitly requires `test.helper` package in the beginning of a test run, if there is a package. We use the assumption that `test.helper` package exist and required to find the module root in `cfg_test` in tarantool/metrics.

These tests are also included in tarantool/tarantool repo as a submodule. Paths are workarounded before the run [1] so we can reuse existing tests and not rewrite them. But `test.helper` path is not workarounded since we do not need this file. Moreover, we shouldn't use it in tarantool/tarantool since it asserts that non-built-in package is used, while we test built-in one there. But tarantool/tarantool tests actually use `test.helper` to find the root in `cfg_test`. It had worked for tarantool/tarantool tests before because, in fact, we had used luatest `test.helper` package to find the root (and, for some reason, it was fine). After [2], there is no luatest `test.helper` anymore and root search fails [3].

This patch makes `cfg_test` to set LUA_PATH to `nil` if we're testing built-in package in tarantool/tarantool since we don't need any rock files.

1. https://github.com/tarantool/tarantool/blob/13159230cfd9ec46b93ad7e6185a3204e27b5b50/test/metrics-luatest/helper.lua#L111-L112
2. https://github.com/tarantool/luatest/pull/307
3. https://github.com/tarantool/tarantool/pull/8683#issuecomment-1558074337

Closes #456
