### PR TITLE
test: run on separate server if box.cfg required

### DIFF
--- a/test/collectors/counter_test.lua
+++ b/test/collectors/counter_test.lua
@@ -4,8 +4,6 @@ local g = t.group()
 local metrics = require('metrics')
 local utils = require('test.utils')
 
-g.before_all(utils.init)
-
 g.after_each(function()
     -- Delete all collectors and global labels
     metrics.clear()

--- a/test/collectors/gauge_test.lua
+++ b/test/collectors/gauge_test.lua
@@ -4,8 +4,6 @@ local g = t.group()
 local metrics = require('metrics')
 local utils = require('test.utils')
 
-g.before_all(utils.init)
-
 g.after_each(function()
     -- Delete all collectors and global labels
     metrics.clear()

--- a/test/helper.lua
+++ b/test/helper.lua
@@ -11,7 +11,8 @@ local root = fio.dirname(fio.dirname(fio.abspath(package.search('test.utils'))))
 
 package.loaded['test.utils'].LUA_PATH = root .. '/?.lua;' ..
     root .. '/?/init.lua;' ..
-    root .. '/.rocks/share/tarantool/?.lua'
+    root .. '/.rocks/share/tarantool/?.lua;' ..
+    root .. '/.rocks/share/tarantool/?/init.lua'
 
 local t = require('luatest')
 local ok, cartridge_helpers = pcall(require, 'cartridge.test-helpers')

--- a/test/integration/highload_test.lua
+++ b/test/integration/highload_test.lua
@@ -1,49 +1,45 @@
 require('strict').on()
 
-local fio = require('fio')
-
 local t = require('luatest')
 local g = t.group('highload')
+local utils = require('test.utils')
 
-g.test_eventloop = function()
-    local tmpdir = fio.tempdir()
-    if type(box.cfg) == 'function' then
-        box.cfg {
-            wal_dir = tmpdir,
-            memtx_dir = tmpdir,
-        }
-    end
+g.before_all(utils.create_server)
 
-    local metrics = require('metrics')
-    local fiber = require('fiber')
-    local clock = require('clock')
-    local utils = require('test.utils')
+g.after_all(utils.drop_server)
 
-    local function monitor(collector)
-        local time_before
-        while true do
-            time_before = clock.monotonic()
-            fiber.yield()
-            collector:observe(clock.monotonic() - time_before)
+g.test_eventloop = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local fiber = require('fiber')
+        local clock = require('clock')
+        local utils = require('test.utils') -- luacheck: ignore 431
+
+        local function monitor(collector)
+            local time_before
+            while true do
+                time_before = clock.monotonic()
+                fiber.yield()
+                collector:observe(clock.monotonic() - time_before)
+            end
         end
-    end
 
-    metrics.set_global_labels({ alias = 'my_instance' })
+        metrics.set_global_labels({ alias = 'my_instance' })
 
-    local collector = metrics.summary('tnt_fiber_event_loop', 'event loop time',
-        { [0.5] = 0.01, [0.9] = 0.01, [0.99] = 0.01, })
-    local fiber_object = fiber.create(function() monitor(collector) end)
+        local collector = metrics.summary('tnt_fiber_event_loop', 'event loop time',
+            { [0.5] = 0.01, [0.9] = 0.01, [0.99] = 0.01, })
+        local fiber_object = fiber.create(function() monitor(collector) end)
 
-    for _ = 1, 10 do
-        fiber.sleep(0.1)
-        local observations = metrics.collect()
+        for _ = 1, 10 do
+            fiber.sleep(0.1)
+            local observations = metrics.collect()
 
-        local obs_summary = utils.find_obs('tnt_fiber_event_loop',
-            { alias = 'my_instance', quantile = 0.99 }, observations)
+            local obs_summary = utils.find_obs('tnt_fiber_event_loop',
+                { alias = 'my_instance', quantile = 0.99 }, observations)
 
-        t.assert_not_inf(obs_summary.value)
-    end
+            t.assert_not_inf(obs_summary.value)
+        end
 
-    fiber.kill(fiber_object:id())
-
+        fiber.kill(fiber_object:id())
+    end)
 end

--- a/test/integration/hotreload_test.lua
+++ b/test/integration/hotreload_test.lua
@@ -1,67 +1,71 @@
 require('strict').on()
 
-local fio = require('fio')
-
 local t = require('luatest')
 local g = t.group('hotreload')
 
 local utils = require('test.utils')
 
-local function package_reload()
-    for k, _ in pairs(package.loaded) do
-        if k:find('metrics') ~= nil then
-            package.loaded[k] = nil
+g.before_all(function(cg)
+    utils.create_server(cg)
+    cg.server:exec(function()
+        local function package_reload()
+            for k, _ in pairs(package.loaded) do
+                if k:find('metrics') ~= nil then
+                    package.loaded[k] = nil
+                end
+            end
+
+            return require('metrics')
         end
-    end
 
-    return require('metrics')
+        rawset(_G, 'package_reload', package_reload)
+    end)
+end)
+
+g.after_all(utils.drop_server)
+
+g.test_reload = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+
+        local http_requests_total_counter = metrics.counter('http_requests_total')
+        http_requests_total_counter:inc(1, {method = 'GET'})
+
+        local http_requests_latency = metrics.summary(
+            'http_requests_latency', 'HTTP requests total',
+            {[0.5]=0.01, [0.9]=0.01, [0.99]=0.01}
+        )
+        http_requests_latency:observe(10)
+
+        metrics.enable_default_metrics()
+
+        metrics = rawget(_G, 'package_reload')()
+
+        metrics.enable_default_metrics()
+    end)
 end
 
-g.test_reload = function()
-    local tmpdir = fio.tempdir()
-    if type(box.cfg) == 'function' then
-        box.cfg {
-            wal_dir = tmpdir,
-            memtx_dir = tmpdir,
-        }
-    end
+g.test_cartridge_hotreload_preserves_cfg_state = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
 
-    local metrics = require('metrics')
+        local cfg_before_hotreload = metrics.cfg{include = {'operations'}}
+        local obs_before_hotreload = metrics.collect{invoke_callbacks = true}
 
-    local http_requests_total_counter = metrics.counter('http_requests_total')
-    http_requests_total_counter:inc(1, {method = 'GET'})
+        metrics = rawget(_G, 'package_reload')()
 
-    local http_requests_latency = metrics.summary(
-        'http_requests_latency', 'HTTP requests total',
-        {[0.5]=0.01, [0.9]=0.01, [0.99]=0.01}
-    )
-    http_requests_latency:observe(10)
+        local cfg_after_hotreload = metrics.cfg
+        box.space._space:select(nil, {limit = 1})
+        local obs_after_hotreload = metrics.collect{invoke_callbacks = true}
 
-    metrics.enable_default_metrics()
+        t.assert_equals(cfg_before_hotreload, cfg_after_hotreload,
+            "cfg values are preserved")
 
-    metrics = package_reload()
-
-    metrics.enable_default_metrics()
-end
-
-g.test_cartridge_hotreload_preserves_cfg_state = function()
-    local metrics = require('metrics')
-
-    local cfg_before_hotreload = metrics.cfg{include = {'operations'}}
-    local obs_before_hotreload = metrics.collect{invoke_callbacks = true}
-
-    metrics = package_reload()
-
-    local cfg_after_hotreload = metrics.cfg
-    box.space._space:select(nil, {limit = 1})
-    local obs_after_hotreload = metrics.collect{invoke_callbacks = true}
-
-    t.assert_equals(cfg_before_hotreload, cfg_after_hotreload,
-        "cfg values are preserved")
-
-    local op_before = utils.find_obs('tnt_stats_op_total', {operation = 'select'},
-        obs_before_hotreload, t.assert_covers)
-    local op_after = utils.find_obs('tnt_stats_op_total', {operation = 'select'},
-        obs_after_hotreload, t.assert_covers)
-    t.assert_gt(op_after.value, op_before.value, "metric callbacks enabled by cfg stay enabled")
+        local op_before = utils.find_obs('tnt_stats_op_total', {operation = 'select'},
+            obs_before_hotreload, t.assert_covers)
+        local op_after = utils.find_obs('tnt_stats_op_total', {operation = 'select'},
+            obs_after_hotreload, t.assert_covers)
+        t.assert_gt(op_after.value, op_before.value, "metric callbacks enabled by cfg stay enabled")
+    end)
 end

--- a/test/plugins/graphite_test.lua
+++ b/test/plugins/graphite_test.lua
@@ -5,124 +5,157 @@ require('strict').on()
 local t = require('luatest')
 local g = t.group()
 
-local metrics = require('metrics')
-local fiber = require('fiber')
-local fun = require('fun')
 local socket = require('socket')
-local graphite = require('metrics.plugins.graphite')
 local utils = require('test.utils')
 
-g.before_all(function()
-    utils.init()
-    local s = box.schema.space.create(
-        'random_space_for_graphite',
-        {if_not_exists = true})
-    s:create_index('pk', {if_not_exists = true})
+g.before_all(function(cg)
+    utils.create_server(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
 
-    local s_vinyl = box.schema.space.create(
-        'random_vinyl_space_for_graphite',
-        {if_not_exists = true, engine = 'vinyl'})
-    s_vinyl:create_index('pk', {if_not_exists = true})
+        local s = box.schema.space.create(
+            'random_space_for_graphite',
+            {if_not_exists = true})
+        s:create_index('pk', {if_not_exists = true})
 
-    -- Delete all previous collectors and global labels
-    metrics.clear()
+        local s_vinyl = box.schema.space.create(
+            'random_vinyl_space_for_graphite',
+            {if_not_exists = true, engine = 'vinyl'})
+        s_vinyl:create_index('pk', {if_not_exists = true})
 
-    -- Enable default metrics collections
-    metrics.enable_default_metrics()
+        -- Enable default metrics collections
+        metrics.enable_default_metrics()
+    end)
 end)
 
-g.before_each(function()
-    metrics.clear()
+g.after_all(utils.drop_server)
+
+g.before_each(function(cg)
+    cg.server:exec(function() require('metrics').clear() end)
 end)
 
-g.after_each(function()
-    -- Delete all collectors and global labels
-    metrics.clear()
-    fun.iter(fiber.info()):
-        filter(function(_, x) return x.name == 'metrics_graphite_worker' end):
-        each(function(x) fiber.kill(x) end)
-    fiber.yield() -- let cancelled fibers disappear from fiber.info()
+g.after_each(function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local fun = require('fun')
+        local metrics = require('metrics')
+        -- Delete all collectors and global labels
+        metrics.clear()
+        fun.iter(fiber.info()):
+            filter(function(_, x) return x.name == 'metrics_graphite_worker' end):
+            each(function(x) fiber.kill(x) end)
+        fiber.yield() -- let cancelled fibers disappear from fiber.info()
+    end)
 end)
 
-g.test_graphite_format_observation_removes_ULL_suffix = function()
-    local gauge = metrics.gauge('test_gauge', 'Test gauge')
-    gauge:set(1ULL)
-    local obs = gauge:collect()[1]
-    local ull_number = tostring(obs.value)
-    t.assert_equals(ull_number, '1ULL')
+g.test_graphite_format_observation_removes_ULL_suffix = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local graphite = require('metrics.plugins.graphite')
 
-    local graphite_obs = graphite.format_observation('', obs)
+        local gauge = metrics.gauge('test_gauge', 'Test gauge')
+        gauge:set(1ULL)
+        local obs = gauge:collect()[1]
+        local ull_number = tostring(obs.value)
+        t.assert_equals(ull_number, '1ULL')
 
-    local graphite_val = graphite_obs:split(' ')[2]
-    t.assert_equals(graphite_val, '1')
+        local graphite_obs = graphite.format_observation('', obs)
+
+        local graphite_val = graphite_obs:split(' ')[2]
+        t.assert_equals(graphite_val, '1')
+    end)
 end
 
-g.test_graphite_format_observation_removes_LL_suffix = function()
-    local gauge = metrics.gauge('test_gauge', 'Test gauge')
-    gauge:set(1LL)
-    local obs = gauge:collect()[1]
-    local ll_number = tostring(obs.value)
-    t.assert_equals(ll_number, '1LL')
+g.test_graphite_format_observation_removes_LL_suffix = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local graphite = require('metrics.plugins.graphite')
 
-    local graphite_obs = graphite.format_observation('', obs)
+        local gauge = metrics.gauge('test_gauge', 'Test gauge')
+        gauge:set(1LL)
+        local obs = gauge:collect()[1]
+        local ll_number = tostring(obs.value)
+        t.assert_equals(ll_number, '1LL')
 
-    local graphite_val = graphite_obs:split(' ')[2]
-    t.assert_equals(graphite_val, '1')
+        local graphite_obs = graphite.format_observation('', obs)
+
+        local graphite_val = graphite_obs:split(' ')[2]
+        t.assert_equals(graphite_val, '1')
+    end)
 end
 
-g.test_graphite_format_observation_float = function()
-    local gauge = metrics.gauge('test_gauge', 'Test gauge')
-    gauge:set(1.5)
-    local obs = gauge:collect()[1]
-    local ll_number = tostring(obs.value)
-    t.assert_equals(ll_number, '1.5')
+g.test_graphite_format_observation_float = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local graphite = require('metrics.plugins.graphite')
 
-    local graphite_obs = graphite.format_observation('', obs)
+        local gauge = metrics.gauge('test_gauge', 'Test gauge')
+        gauge:set(1.5)
+        local obs = gauge:collect()[1]
+        local ll_number = tostring(obs.value)
+        t.assert_equals(ll_number, '1.5')
 
-    local graphite_val = graphite_obs:split(' ')[2]
-    t.assert_equals(graphite_val, '1.5')
+        local graphite_obs = graphite.format_observation('', obs)
+
+        local graphite_val = graphite_obs:split(' ')[2]
+        t.assert_equals(graphite_val, '1.5')
+    end)
 end
 
-g.test_graphite_format_observation_time_in_seconds = function()
-    local obs = {
-        metric_name = 'test_metric',
-        label_pairs = {},
-        value = 1,
-        timestamp = fiber.time64(),
-    }
+g.test_graphite_format_observation_time_in_seconds = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local graphite = require('metrics.plugins.graphite')
 
-    local graphite_obs = graphite.format_observation('', obs)
+        local obs = {
+            metric_name = 'test_metric',
+            label_pairs = {},
+            value = 1,
+            timestamp = fiber.time64(),
+        }
 
-    local graphite_time = tonumber(graphite_obs:split(' ')[3])
-    local sec = obs.timestamp / 10^6
-    t.assert_equals(graphite_time, sec)
+        local graphite_obs = graphite.format_observation('', obs)
+
+        local graphite_time = tonumber(graphite_obs:split(' ')[3])
+        local sec = obs.timestamp / 10^6
+        t.assert_equals(graphite_time, sec)
+    end)
 end
 
-g.test_graphite_format_observation_signed_time = function()
-    local obs = {
-        metric_name = 'test_metric',
-        label_pairs = {},
-        value = 1,
-        timestamp = 1000000000000LL,
-    }
+g.test_graphite_format_observation_signed_time = function(cg)
+    cg.server:exec(function()
+        local graphite = require('metrics.plugins.graphite')
 
-    local graphite_obs = graphite.format_observation('', obs)
+        local obs = {
+            metric_name = 'test_metric',
+            label_pairs = {},
+            value = 1,
+            timestamp = 1000000000000LL,
+        }
 
-    local graphite_time = tonumber(graphite_obs:split(' ')[3])
-    local sec = obs.timestamp / 10^6
-    t.assert_equals(graphite_time, sec)
+        local graphite_obs = graphite.format_observation('', obs)
+
+        local graphite_time = tonumber(graphite_obs:split(' ')[3])
+        local sec = obs.timestamp / 10^6
+        t.assert_equals(graphite_time, sec)
+    end)
 end
 
-g.test_graphite_sends_data_to_socket = function()
-    local cnt = metrics.counter('test_cnt', 'test-cnt')
-    cnt:inc(1)
+g.test_graphite_sends_data_to_socket = function(cg)
     local port = 22003
     local sock = socket('AF_INET', 'SOCK_DGRAM', 'udp')
     sock:bind('127.0.0.1', port)
 
-    graphite.init({port = port})
+    cg.server:exec(function(port) -- luacheck: ignore 431
+        local metrics = require('metrics')
+        local graphite = require('metrics.plugins.graphite')
 
-    fiber.sleep(0.5)
+        local cnt = metrics.counter('test_cnt', 'test-cnt')
+        cnt:inc(1)
+        graphite.init({port = port})
+    end, {port})
+
+    require('fiber').sleep(0.5)
     local graphite_obs = sock:recvfrom(50)
     local obs_table = graphite_obs:split(' ')
     t.assert_equals(obs_table[1], 'tarantool.test_cnt')
@@ -130,26 +163,32 @@ g.test_graphite_sends_data_to_socket = function()
     sock:close()
 end
 
-local function mock_graphite_worker()
-    fiber.create(function()
-        fiber.name('metrics_graphite_worker')
-        fiber.sleep(math.huge)
+g.test_graphite_kills_previous_fibers_on_init = function(cg)
+    cg.server:exec(function()
+        local fiber = require('fiber')
+        local fun = require('fun')
+        local graphite = require('metrics.plugins.graphite')
+
+        local function mock_graphite_worker()
+            fiber.create(function()
+                fiber.name('metrics_graphite_worker')
+                fiber.sleep(math.huge)
+            end)
+        end
+
+        local function count_workers()
+            return fun.iter(fiber.info()):
+                filter(function(_, x) return x.name == 'metrics_graphite_worker' end):
+                length()
+        end
+
+        t.assert_equals(count_workers(), 0)
+        mock_graphite_worker()
+        mock_graphite_worker()
+        t.assert_equals(count_workers(), 2)
+
+        graphite.init({})
+        fiber.yield() -- let cancelled fibers disappear from fiber.info()
+        t.assert_equals(count_workers(), 1)
     end)
-end
-
-local function count_workers()
-    return fun.iter(fiber.info()):
-        filter(function(_, x) return x.name == 'metrics_graphite_worker' end):
-        length()
-end
-
-g.test_graphite_kills_previous_fibers_on_init = function()
-    t.assert_equals(count_workers(), 0)
-    mock_graphite_worker()
-    mock_graphite_worker()
-    t.assert_equals(count_workers(), 2)
-
-    graphite.init({})
-    fiber.yield() -- let cancelled fibers disappear from fiber.info()
-    t.assert_equals(count_workers(), 1)
 end

--- a/test/plugins/json_test.lua
+++ b/test/plugins/json_test.lua
@@ -8,8 +8,6 @@ local metrics = require('metrics')
 local json = require('json')
 local utils = require('test.utils')
 
-g.before_all(utils.init)
-
 g.after_each(function()
     -- Delete all collectors and global labels
     metrics.clear()

--- a/test/plugins/prometheus_test.lua
+++ b/test/plugins/prometheus_test.lua
@@ -5,32 +5,29 @@ require('strict').on()
 local t = require('luatest')
 local g = t.group('prometheus_plugin')
 
-local metrics = require('metrics')
-local http_handler = require('metrics.plugins.prometheus').collect_http
 local utils = require('test.utils')
 
-g.before_all(function()
-    utils.init()
-    local s = box.schema.space.create(
-        'random_space_for_prometheus',
-        {if_not_exists = true})
-    s:create_index('pk', {if_not_exists = true})
+g.before_all(function(cg)
+    utils.create_server(cg)
+    cg.prometheus_metrics = cg.server:exec(function()
+        local s = box.schema.space.create(
+            'random_space_for_prometheus',
+            {if_not_exists = true})
+        s:create_index('pk', {if_not_exists = true})
 
-    local s_vinyl = box.schema.space.create(
-        'random_vinyl_space_for_prometheus',
-        {if_not_exists = true, engine = 'vinyl'})
-    s_vinyl:create_index('pk', {if_not_exists = true})
+        local s_vinyl = box.schema.space.create(
+            'random_vinyl_space_for_prometheus',
+            {if_not_exists = true, engine = 'vinyl'})
+        s_vinyl:create_index('pk', {if_not_exists = true})
 
-    -- Enable default metrics collections
-    metrics.enable_default_metrics()
+        -- Enable default metrics collections
+        require('metrics').enable_default_metrics()
 
-    g.prometheus_metrics = http_handler().body
+        return require('metrics.plugins.prometheus').collect_http().body
+    end)
 end)
 
-g.after_each(function()
-    -- Delete all collectors and global labels
-    metrics.clear()
-end)
+g.after_all(utils.drop_server)
 
 g.test_ll_ull_postfixes = function()
     local resp = g.prometheus_metrics

--- a/test/psutils_linux_test.lua
+++ b/test/psutils_linux_test.lua
@@ -2,45 +2,53 @@
 
 local t = require('luatest')
 local g = t.group('psutils_linux')
+local utils = require('test.utils')
 
-local fio = require('fio')
-local fio_impl = table.deepcopy(fio)
-
-local psutils_mock = require('test.psutils_linux_test_payload')
-
-local psutils_linux = require('metrics.psutils.psutils_linux')
-
-g.before_all(function()
+g.before_all(function(cg)
     t.skip_if(jit.os ~= 'Linux', 'Linux is the only supported platform')
+    utils.create_server(cg)
 
-    fio.open = function(path, mode)
-        return fio_impl.open(psutils_mock.files[path], mode)
-    end
-    fio.listdir = function(_)
-        return fio_impl.listdir(psutils_mock.task_dir_path)
-    end
+    cg.server:exec(function()
+        local fio = require('fio')
+        local fio_impl = table.deepcopy(fio)
+
+        local psutils_mock = require('test.psutils_linux_test_payload')
+
+        fio.open = function(path, mode)
+            return fio_impl.open(psutils_mock.files[path], mode)
+        end
+        fio.listdir = function(_)
+            return fio_impl.listdir(psutils_mock.task_dir_path)
+        end
+    end)
 end)
 
-g.after_all(function()
-    fio.open = fio_impl.open
-    fio.listdir = fio_impl.listdir
-end)
+g.after_all(utils.drop_server)
 
-g.test_get_cpu_time = function()
-    local expected = 138445
-    t.assert_equals(psutils_linux.get_cpu_time(), expected)
+g.test_get_cpu_time = function(cg)
+    cg.server:exec(function()
+        local psutils_linux = require('metrics.psutils.psutils_linux')
+        local expected = 138445
+        t.assert_equals(psutils_linux.get_cpu_time(), expected)
+    end)
 end
 
-g.test_get_process_cpu_time = function()
-    local expected = {
-        {pid = 1, comm = 'tarantool', utime = 468, stime = 171},
-        {pid = 12, comm = 'coio', utime = 0, stime = 0},
-        {pid = 13, comm = 'iproto', utime = 118, stime = 534},
-        {pid = 14, comm = 'wal', utime = 0, stime = 0},
-    }
-    t.assert_items_equals(psutils_linux.get_process_cpu_time(), expected)
+g.test_get_process_cpu_time = function(cg)
+    cg.server:exec(function()
+        local psutils_linux = require('metrics.psutils.psutils_linux')
+        local expected = {
+            {pid = 1, comm = 'tarantool', utime = 468, stime = 171},
+            {pid = 12, comm = 'coio', utime = 0, stime = 0},
+            {pid = 13, comm = 'iproto', utime = 118, stime = 534},
+            {pid = 14, comm = 'wal', utime = 0, stime = 0},
+        }
+        t.assert_items_equals(psutils_linux.get_process_cpu_time(), expected)
+    end)
 end
 
-g.test_get_cpu_count = function()
-    t.assert_gt(psutils_linux.get_cpu_count(), 0)
+g.test_get_cpu_count = function(cg)
+    cg.server:exec(function()
+        local psutils_linux = require('metrics.psutils.psutils_linux')
+        t.assert_gt(psutils_linux.get_cpu_count(), 0)
+    end)
 end

--- a/test/psutils_linux_thread_clean_test.lua
+++ b/test/psutils_linux_thread_clean_test.lua
@@ -3,81 +3,105 @@
 local t = require('luatest')
 local g = t.group('psutils_linux_clean_info')
 local utils = require('test.utils')
-local metrics = require('metrics')
-local cpu = require('metrics.psutils.cpu')
 
-g.before_all(function()
+g.before_all(function(cg)
     t.skip_if(jit.os ~= 'Linux', 'Linux is the only supported platform')
-    utils.init()
+    utils.create_server(cg)
 end)
 
-g.after_each(function()
-    metrics.clear()
+g.after_all(utils.drop_server)
+
+g.after_each(function(cg)
+    cg.server:exec(function()
+        require('metrics').clear()
+    end)
 end)
 
-g.test_clean_thread_info = function()
-    cpu.update()
-    local observations = metrics.collect()
+g.test_clean_thread_info = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
 
-    local thread_obs = utils.find_metric('tnt_cpu_thread', observations)
-    t.assert_not_equals(thread_obs, nil)
+        require('metrics.psutils.cpu').update()
 
-    local threads = {}
-    for _, obs in ipairs(thread_obs) do
-        threads[obs.label_pairs.thread_pid] = true
-    end
+        local observations = metrics.collect()
 
-    -- After box.cfg{}, there should be at least tx (tarantool), iproto and wal.
-    t.assert_ge(utils.len(threads), 3)
-    t.assert_equals(#thread_obs, 2 * utils.len(threads),
-        'There are two observations for each thread (user and system)')
-end
+        local thread_obs = utils.find_metric('tnt_cpu_thread', observations)
+        t.assert_not_equals(thread_obs, nil)
 
-g.test_cpu_count = function()
-    cpu.update()
-    local observations = metrics.collect()
-    local metric = utils.find_metric('tnt_cpu_number', observations)
-    t.assert_not_equals(metric, nil)
-    t.assert_equals(#metric, 1)
-    t.assert_gt(metric[1].value, 0)
-end
-
-local function check_cpu_metrics(presents)
-    local observations = metrics.collect()
-
-    local expected = {
-        'tnt_cpu_number',
-        'tnt_cpu_time',
-        'tnt_cpu_thread',
-    }
-
-    for _, metric_name in ipairs(expected) do
-        local metric = utils.find_metric(metric_name, observations)
-
-        if presents then
-            t.assert_not_equals(metric, nil)
-        else
-            t.assert_equals(metric, nil)
+        local threads = {}
+        for _, obs in ipairs(thread_obs) do
+            threads[obs.label_pairs.thread_pid] = true
         end
-    end
+
+        -- After box.cfg{}, there should be at least tx (tarantool), iproto and wal.
+        t.assert_ge(utils.len(threads), 3)
+        t.assert_equals(#thread_obs, 2 * utils.len(threads),
+            'There are two observations for each thread (user and system)')
+    end)
 end
 
-g.test_clear = function()
-    cpu.update()
-    check_cpu_metrics(true)
+g.test_cpu_count = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
 
-    cpu.clear()
-    check_cpu_metrics(false)
+        require('metrics.psutils.cpu').update()
 
-    cpu.update()
-    check_cpu_metrics(true)
+        local observations = metrics.collect()
+        local metric = utils.find_metric('tnt_cpu_number', observations)
+        t.assert_not_equals(metric, nil)
+        t.assert_equals(#metric, 1)
+        t.assert_gt(metric[1].value, 0)
+    end)
 end
 
-g.test_default_metrics_metainfo = function()
-    cpu.update()
 
-    for k, c in pairs(metrics.collectors()) do
-        t.assert_equals(c.metainfo.default, true,
-            ('psutils collector %s has metainfo label "default"'):format(k))
-    end
+g.test_clear = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
+        local cpu = require('metrics.psutils.cpu')
+
+        local function check_cpu_metrics(presents)
+
+            local observations = metrics.collect()
+
+            local expected = {
+                'tnt_cpu_number',
+                'tnt_cpu_time',
+                'tnt_cpu_thread',
+            }
+
+            for _, metric_name in ipairs(expected) do
+                local metric = utils.find_metric(metric_name, observations)
+
+                if presents then
+                    t.assert_not_equals(metric, nil)
+                else
+                    t.assert_equals(metric, nil)
+                end
+            end
+        end
+
+        cpu.update()
+        check_cpu_metrics(true)
+
+        cpu.clear()
+        check_cpu_metrics(false)
+
+        cpu.update()
+        check_cpu_metrics(true)
+    end)
+end
+
+g.test_default_metrics_metainfo = function(cg)
+    cg.server:exec(function()
+        require('metrics.psutils.cpu').update()
+
+        for k, c in pairs(require('metrics').collectors()) do
+            t.assert_equals(c.metainfo.default, true,
+                ('psutils collector %s has metainfo label "default"'):format(k))
+        end
+    end)
 end

--- a/test/tarantool/cpu_metrics_test.lua
+++ b/test/tarantool/cpu_metrics_test.lua
@@ -2,26 +2,30 @@
 
 local t = require('luatest')
 local g = t.group('cpu_metric')
-local cpu = require('metrics.tarantool.cpu')
 local utils = require('test.utils')
 
-local metrics = require('metrics')
+g.before_all(utils.create_server)
 
-g.before_all(utils.init)
+g.after_all(utils.drop_server)
 
-g.after_each(function()
-    -- Delete all collectors and global labels
-    metrics.clear()
+g.before_each(function(cg)
+    cg.server:exec(function() require('metrics').clear() end)
 end)
 
-g.test_cpu = function()
-    metrics.enable_default_metrics()
-    cpu.update()
-    local default_metrics = metrics.collect()
-    local user_time_metric = utils.find_metric('tnt_cpu_user_time', default_metrics)
-    local system_time_metric = utils.find_metric('tnt_cpu_system_time', default_metrics)
-    t.assert(user_time_metric)
-    t.assert(system_time_metric)
-    t.assert(user_time_metric[1].value > 0)
-    t.assert(system_time_metric[1].value > 0)
+g.test_cpu = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local cpu = require('metrics.tarantool.cpu')
+        local utils = require('test.utils') -- luacheck: ignore 431
+
+        metrics.enable_default_metrics()
+        cpu.update()
+        local default_metrics = metrics.collect()
+        local user_time_metric = utils.find_metric('tnt_cpu_user_time', default_metrics)
+        local system_time_metric = utils.find_metric('tnt_cpu_system_time', default_metrics)
+        t.assert(user_time_metric)
+        t.assert(system_time_metric)
+        t.assert(user_time_metric[1].value > 0)
+        t.assert(system_time_metric[1].value > 0)
+    end)
 end

--- a/test/tarantool/info_metrics_test.lua
+++ b/test/tarantool/info_metrics_test.lua
@@ -2,78 +2,94 @@
 
 local t = require('luatest')
 local g = t.group('info_metric')
-local info = require('metrics.tarantool.info')
 local utils = require('test.utils')
 
-local metrics = require('metrics')
+g.before_all(utils.create_server)
 
-g.before_all(utils.init)
+g.after_all(utils.drop_server)
 
-g.after_each(function()
-    -- Delete all collectors and global labels
-    metrics.clear()
+g.before_each(function(cg)
+    cg.server:exec(function() require('metrics').clear() end)
 end)
 
-g.test_info = function()
-    metrics.enable_default_metrics()
-    info.update()
-    local default_metrics = metrics.collect()
+g.test_info = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local info = require('metrics.tarantool.info')
+        local utils = require('test.utils') -- luacheck: ignore 431
 
-    local tnt_info_lsn = utils.find_metric('tnt_info_lsn', default_metrics)
-    t.assert(tnt_info_lsn)
-    t.assert_type(tnt_info_lsn[1].value, 'number')
+        metrics.enable_default_metrics()
+        info.update()
+        local default_metrics = metrics.collect()
 
-    local tnt_info_uptime = utils.find_metric('tnt_info_uptime', default_metrics)
-    t.assert(tnt_info_uptime)
-    t.assert_type(tnt_info_uptime[1].value, 'number')
+        local tnt_info_lsn = utils.find_metric('tnt_info_lsn', default_metrics)
+        t.assert(tnt_info_lsn)
+        t.assert_type(tnt_info_lsn[1].value, 'number')
+
+        local tnt_info_uptime = utils.find_metric('tnt_info_uptime', default_metrics)
+        t.assert(tnt_info_uptime)
+        t.assert_type(tnt_info_uptime[1].value, 'number')
+    end)
 end
 
-g.test_synchro_queue = function()
+g.test_synchro_queue = function(cg)
     t.skip_if(utils.is_version_less(_TARANTOOL, '2.7.0'),
         'Tarantool version is must be v2.7.0 or greater')
 
-    metrics.enable_default_metrics()
-    info.update()
-    local default_metrics = metrics.collect()
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local info = require('metrics.tarantool.info')
+        local utils = require('test.utils') -- luacheck: ignore 431
 
-    local tnt_synchro_queue_owner = utils.find_metric('tnt_synchro_queue_owner', default_metrics)
-    t.assert(tnt_synchro_queue_owner)
-    t.assert_type(tnt_synchro_queue_owner[1].value, 'number')
+        metrics.enable_default_metrics()
+        info.update()
+        local default_metrics = metrics.collect()
 
-    local tnt_synchro_queue_term = utils.find_metric('tnt_synchro_queue_term', default_metrics)
-    t.assert(tnt_synchro_queue_term)
-    t.assert_type(tnt_synchro_queue_term[1].value, 'number')
+        local tnt_synchro_queue_owner = utils.find_metric('tnt_synchro_queue_owner', default_metrics)
+        t.assert(tnt_synchro_queue_owner)
+        t.assert_type(tnt_synchro_queue_owner[1].value, 'number')
 
-    local tnt_synchro_queue_len = utils.find_metric('tnt_synchro_queue_len', default_metrics)
-    t.assert(tnt_synchro_queue_len)
-    t.assert_type(tnt_synchro_queue_len[1].value, 'number')
+        local tnt_synchro_queue_term = utils.find_metric('tnt_synchro_queue_term', default_metrics)
+        t.assert(tnt_synchro_queue_term)
+        t.assert_type(tnt_synchro_queue_term[1].value, 'number')
 
-    local tnt_synchro_queue_busy = utils.find_metric('tnt_synchro_queue_busy', default_metrics)
-    t.assert(tnt_synchro_queue_busy)
-    t.assert_type(tnt_synchro_queue_busy[1].value, 'number')
+        local tnt_synchro_queue_len = utils.find_metric('tnt_synchro_queue_len', default_metrics)
+        t.assert(tnt_synchro_queue_len)
+        t.assert_type(tnt_synchro_queue_len[1].value, 'number')
+
+        local tnt_synchro_queue_busy = utils.find_metric('tnt_synchro_queue_busy', default_metrics)
+        t.assert(tnt_synchro_queue_busy)
+        t.assert_type(tnt_synchro_queue_busy[1].value, 'number')
+    end)
 end
 
-g.test_election = function()
+g.test_election = function(cg)
     t.skip_if(utils.is_version_less(_TARANTOOL, '2.7.0'),
         'Tarantool version is must be v2.7.0 or greater')
 
-    metrics.enable_default_metrics()
-    info.update()
-    local default_metrics = metrics.collect()
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local info = require('metrics.tarantool.info')
+        local utils = require('test.utils') -- luacheck: ignore 431
 
-    local tnt_election_state = utils.find_metric('tnt_election_state', default_metrics)
-    t.assert(tnt_election_state)
-    t.assert_type(tnt_election_state[1].value, 'number')
+        metrics.enable_default_metrics()
+        info.update()
+        local default_metrics = metrics.collect()
 
-    local tnt_election_vote = utils.find_metric('tnt_election_vote', default_metrics)
-    t.assert(tnt_election_vote)
-    t.assert_type(tnt_election_vote[1].value, 'number')
+        local tnt_election_state = utils.find_metric('tnt_election_state', default_metrics)
+        t.assert(tnt_election_state)
+        t.assert_type(tnt_election_state[1].value, 'number')
 
-    local tnt_election_leader = utils.find_metric('tnt_election_leader', default_metrics)
-    t.assert(tnt_election_leader)
-    t.assert_type(tnt_election_leader[1].value, 'number')
+        local tnt_election_vote = utils.find_metric('tnt_election_vote', default_metrics)
+        t.assert(tnt_election_vote)
+        t.assert_type(tnt_election_vote[1].value, 'number')
 
-    local tnt_election_term = utils.find_metric('tnt_election_term', default_metrics)
-    t.assert(tnt_election_term)
-    t.assert_type(tnt_election_term[1].value, 'number')
+        local tnt_election_leader = utils.find_metric('tnt_election_leader', default_metrics)
+        t.assert(tnt_election_leader)
+        t.assert_type(tnt_election_leader[1].value, 'number')
+
+        local tnt_election_term = utils.find_metric('tnt_election_term', default_metrics)
+        t.assert(tnt_election_term)
+        t.assert_type(tnt_election_term[1].value, 'number')
+    end)
 end

--- a/test/tarantool/lj_metrics_test.lua
+++ b/test/tarantool/lj_metrics_test.lua
@@ -4,53 +4,62 @@ require('strict').on()
 
 local t = require('luatest')
 local g = t.group('luajit_metrics')
+local utils = require('test.utils')
 
-local metrics = require('metrics')
-
-local LJ_PREFIX = 'lj_'
-
-g.after_each(function()
-    -- Delete all collectors and global labels
-    metrics.clear()
+g.before_all(function(cg)
+    t.skip_if(jit.os ~= 'Linux', 'Linux is the only supported platform')
+    utils.create_server(cg)
 end)
 
-g.test_lj_metrics = function()
-    local metrics_available = pcall(require, 'misc')
-    t.skip_if(metrics_available == false, 'metrics are not available')
+g.after_all(utils.drop_server)
 
-    metrics.enable_default_metrics()
+g.after_each(function(cg)
+    cg.server:exec(function()
+        require('metrics').clear()
+    end)
+end)
 
-    local lj_metrics = {}
-    for _, v in pairs(metrics.collect{invoke_callbacks = true}) do
-        if v.metric_name:startswith(LJ_PREFIX) then
-            table.insert(lj_metrics, v.metric_name)
+g.test_lj_metrics = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+
+        local metrics_available = pcall(require, 'misc')
+        t.skip_if(metrics_available == false, 'metrics are not available')
+
+        metrics.enable_default_metrics()
+
+        local lj_metrics = {}
+        for _, v in pairs(metrics.collect{invoke_callbacks = true}) do
+            if v.metric_name:startswith('lj_') then
+                table.insert(lj_metrics, v.metric_name)
+            end
         end
-    end
-    table.sort(lj_metrics)
+        table.sort(lj_metrics)
 
-    local expected_lj_metrics = {
-        "lj_gc_freed_total",
-        "lj_strhash_hit_total",
-        "lj_gc_steps_atomic_total",
-        "lj_strhash_miss_total",
-        "lj_gc_steps_sweepstring_total",
-        "lj_gc_strnum",
-        "lj_gc_tabnum",
-        "lj_gc_cdatanum",
-        "lj_jit_snap_restore_total",
-        "lj_gc_memory",
-        "lj_gc_udatanum",
-        "lj_gc_steps_finalize_total",
-        "lj_gc_allocated_total",
-        "lj_jit_trace_num",
-        "lj_gc_steps_sweep_total",
-        "lj_jit_trace_abort_total",
-        "lj_jit_mcode_size",
-        "lj_gc_steps_propagate_total",
-        "lj_gc_steps_pause_total",
-    }
-    table.sort(expected_lj_metrics)
+        local expected_lj_metrics = {
+            "lj_gc_freed_total",
+            "lj_strhash_hit_total",
+            "lj_gc_steps_atomic_total",
+            "lj_strhash_miss_total",
+            "lj_gc_steps_sweepstring_total",
+            "lj_gc_strnum",
+            "lj_gc_tabnum",
+            "lj_gc_cdatanum",
+            "lj_jit_snap_restore_total",
+            "lj_gc_memory",
+            "lj_gc_udatanum",
+            "lj_gc_steps_finalize_total",
+            "lj_gc_allocated_total",
+            "lj_jit_trace_num",
+            "lj_gc_steps_sweep_total",
+            "lj_jit_trace_abort_total",
+            "lj_jit_mcode_size",
+            "lj_gc_steps_propagate_total",
+            "lj_gc_steps_pause_total",
+        }
+        table.sort(expected_lj_metrics)
 
-    t.assert_equals(#lj_metrics, #expected_lj_metrics)
-    t.assert_items_equals(lj_metrics, expected_lj_metrics)
+        t.assert_equals(#lj_metrics, #expected_lj_metrics)
+        t.assert_items_equals(lj_metrics, expected_lj_metrics)
+    end)
 end

--- a/test/tarantool/memtx_metrics_test.lua
+++ b/test/tarantool/memtx_metrics_test.lua
@@ -2,60 +2,64 @@
 
 local t = require('luatest')
 local g = t.group('memtx_metric')
-local memtx = require('metrics.tarantool.memtx')
 local utils = require('test.utils')
 
-local metrics = require('metrics')
+g.before_all(utils.create_server)
 
-g.before_all(utils.init)
+g.after_all(utils.drop_server)
 
-g.after_each(function()
-    -- Delete all collectors and global labels
-    metrics.clear()
+g.before_each(function(cg)
+    cg.server:exec(function() require('metrics').clear() end)
 end)
 
-g.test_memtx = function()
+g.test_memtx = function(cg)
     t.skip_if(utils.is_version_less(_TARANTOOL, '2.10.0'),
         'Tarantool version is must be v2.10.0 or greater')
 
-    metrics.enable_default_metrics()
-    memtx.update()
-    local default_metrics = metrics.collect()
-    local log = require('log')
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local memtx = require('metrics.tarantool.memtx')
+        local utils = require('test.utils') -- luacheck: ignore 431
 
-    local metrics_list1 = {
-        'tnt_memtx_tnx_statements',
-        'tnt_memtx_tnx_user',
-        'tnt_memtx_tnx_system',
-        'tnt_memtx_mvcc_trackers',
-        'tnt_memtx_mvcc_conflicts',
-    }
+        metrics.enable_default_metrics()
+        memtx.update()
+        local default_metrics = metrics.collect()
+        local log = require('log')
 
-    for _, item in ipairs(metrics_list1) do
-        log.info('checking metric: ' .. item)
-        local metric = utils.find_metric(item, default_metrics)
-        t.assert(metric)
-        t.assert_type(metric[1].value, 'number')
-        t.assert_items_equals(metric[1].label_pairs, {kind = "average"})
-        t.assert_items_equals(metric[2].label_pairs, {kind = "total"})
-        t.assert_items_equals(metric[3].label_pairs, {kind = "max"})
-    end
+        local metrics_list1 = {
+            'tnt_memtx_tnx_statements',
+            'tnt_memtx_tnx_user',
+            'tnt_memtx_tnx_system',
+            'tnt_memtx_mvcc_trackers',
+            'tnt_memtx_mvcc_conflicts',
+        }
 
-    local metrics_list2 = {
-        'tnt_memtx_mvcc_tuples_tracking_stories',
-        'tnt_memtx_mvcc_tuples_tracking_retained',
-        'tnt_memtx_mvcc_tuples_used_stories',
-        'tnt_memtx_mvcc_tuples_used_retained',
-        'tnt_memtx_mvcc_tuples_read_view_stories',
-        'tnt_memtx_mvcc_tuples_read_view_retained',
-    }
+        for _, item in ipairs(metrics_list1) do
+            log.info('checking metric: ' .. item)
+            local metric = utils.find_metric(item, default_metrics)
+            t.assert(metric)
+            t.assert_type(metric[1].value, 'number')
+            t.assert_items_equals(metric[1].label_pairs, {kind = "average"})
+            t.assert_items_equals(metric[2].label_pairs, {kind = "total"})
+            t.assert_items_equals(metric[3].label_pairs, {kind = "max"})
+        end
 
-    for _, item in ipairs(metrics_list2) do
-        log.info('checking metric: ' .. item)
-        local metric = utils.find_metric(item, default_metrics)
-        t.assert(metric)
-        t.assert_type(metric[1].value, 'number')
-        t.assert_items_equals(metric[1].label_pairs, {kind = "total"})
-        t.assert_items_equals(metric[2].label_pairs, {kind = "count"})
-    end
+        local metrics_list2 = {
+            'tnt_memtx_mvcc_tuples_tracking_stories',
+            'tnt_memtx_mvcc_tuples_tracking_retained',
+            'tnt_memtx_mvcc_tuples_used_stories',
+            'tnt_memtx_mvcc_tuples_used_retained',
+            'tnt_memtx_mvcc_tuples_read_view_stories',
+            'tnt_memtx_mvcc_tuples_read_view_retained',
+        }
+
+        for _, item in ipairs(metrics_list2) do
+            log.info('checking metric: ' .. item)
+            local metric = utils.find_metric(item, default_metrics)
+            t.assert(metric)
+            t.assert_type(metric[1].value, 'number')
+            t.assert_items_equals(metric[1].label_pairs, {kind = "total"})
+            t.assert_items_equals(metric[2].label_pairs, {kind = "count"})
+        end
+    end)
 end

--- a/test/tarantool/spaces_test.lua
+++ b/test/tarantool/spaces_test.lua
@@ -3,225 +3,259 @@ require('strict').on()
 local t = require('luatest')
 local g = t.group()
 
-local metrics = require('metrics')
-local fun = require('fun')
 local utils = require('test.utils')
 
-g.before_each(function()
-    rawset(_G, 'include_vinyl_count', true)
+g.before_all(utils.create_server)
 
-    utils.init()
-    utils.clear_spaces()
+g.after_all(utils.drop_server)
 
-    for _, engine in ipairs({'memtx', 'vinyl'}) do
-        for i = 1, 3 do
-            local space_name = engine .. '_space_' .. tostring(i)
-            local s = box.schema.space.create(space_name, {engine = engine})
-            for j = 1, 3 do
-                s:create_index('index_' .. tostring(j))
+g.before_each(function(cg)
+    cg.server:exec(function()
+        local fun = require('fun')
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
+
+        rawset(_G, 'include_vinyl_count', true)
+
+        utils.clear_spaces()
+
+        for _, engine in ipairs({'memtx', 'vinyl'}) do
+            for i = 1, 3 do
+                local space_name = engine .. '_space_' .. tostring(i)
+                local s = box.schema.space.create(space_name, {engine = engine})
+                for j = 1, 3 do
+                    s:create_index('index_' .. tostring(j))
+                end
             end
         end
-    end
 
-    metrics.enable_default_metrics()
+        metrics.enable_default_metrics()
+
+        local function get_space_metrics(metric_name)
+            return fun.iter(metrics.collect{invoke_callbacks = true}):filter(function(x)
+                return x.metric_name:find(metric_name)
+            end):map(function(m) return m.label_pairs end):totable()
+        end
+
+        rawset(_G, 'get_space_metrics', get_space_metrics)
+    end)
 end)
 
-g.after_each(function()
-    -- Delete all collectors and global labels
-    metrics.clear()
-    utils.clear_spaces()
-    rawset(_G, 'include_vinyl_count', false)
+g.after_each(function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
+
+        metrics.clear()
+        utils.clear_spaces()
+        rawset(_G, 'include_vinyl_count', false)
+    end)
 end)
 
-local function get_space_metrics(metric_name)
-    return fun.iter(metrics.collect{invoke_callbacks = true}):filter(function(x)
-        return x.metric_name:find(metric_name)
-    end):map(function(m) return m.label_pairs end):totable()
+
+g.test_spaces = function(cg)
+    cg.server:exec(function()
+        local get_space_metrics = rawget(_G, 'get_space_metrics')
+
+        local metrics_list = get_space_metrics('tnt_space')
+
+        t.assert_items_include(metrics_list, {
+            {engine = 'memtx', name = 'memtx_space_1'},
+            {engine = 'memtx', name = 'memtx_space_2'},
+            {engine = 'memtx', name = 'memtx_space_3'},
+        })
+
+        metrics_list = get_space_metrics('tnt_vinyl_tuples')
+        t.assert_items_include(metrics_list, {
+            {engine = 'vinyl', name = 'vinyl_space_1'},
+            {engine = 'vinyl', name = 'vinyl_space_2'},
+            {engine = 'vinyl', name = 'vinyl_space_3'},
+        })
+    end)
 end
 
-g.test_spaces = function()
-    local metrics_list = get_space_metrics('tnt_space')
+g.test_indexes = function(cg)
+    cg.server:exec(function()
+        local get_space_metrics = rawget(_G, 'get_space_metrics')
 
-    t.assert_items_include(metrics_list, {
-        {engine = 'memtx', name = 'memtx_space_1'},
-        {engine = 'memtx', name = 'memtx_space_2'},
-        {engine = 'memtx', name = 'memtx_space_3'},
-    })
+        local metrics_list = get_space_metrics('tnt_space')
 
-    metrics_list = get_space_metrics('tnt_vinyl_tuples')
-    t.assert_items_include(metrics_list, {
-        {engine = 'vinyl', name = 'vinyl_space_1'},
-        {engine = 'vinyl', name = 'vinyl_space_2'},
-        {engine = 'vinyl', name = 'vinyl_space_3'},
-    })
+        t.assert_items_include(metrics_list, {
+            {index_name = 'index_1', name = 'memtx_space_1'},
+            {index_name = 'index_2', name = 'memtx_space_1'},
+            {index_name = 'index_3', name = 'memtx_space_1'},
+        })
+        t.assert_items_include(metrics_list, {
+            {index_name = 'index_1', name = 'vinyl_space_1'},
+            {index_name = 'index_2', name = 'vinyl_space_2'},
+            {index_name = 'index_3', name = 'vinyl_space_3'},
+        })
+    end)
 end
 
-g.test_indexes = function()
-    local metrics_list = get_space_metrics('tnt_space')
+g.test_disable_vinyl = function(cg)
+    cg.server:exec(function()
+        local get_space_metrics = rawget(_G, 'get_space_metrics')
 
-    t.assert_items_include(metrics_list, {
-        {index_name = 'index_1', name = 'memtx_space_1'},
-        {index_name = 'index_2', name = 'memtx_space_1'},
-        {index_name = 'index_3', name = 'memtx_space_1'},
-    })
-    t.assert_items_include(metrics_list, {
-        {index_name = 'index_1', name = 'vinyl_space_1'},
-        {index_name = 'index_2', name = 'vinyl_space_2'},
-        {index_name = 'index_3', name = 'vinyl_space_3'},
-    })
+        local metrics_list = get_space_metrics('tnt_vinyl_tuples')
+
+        t.assert_items_include(metrics_list, {
+            {engine = 'vinyl', name = 'vinyl_space_1'},
+            {engine = 'vinyl', name = 'vinyl_space_2'},
+            {engine = 'vinyl', name = 'vinyl_space_3'},
+        })
+
+        local metrics_vinyl_index = get_space_metrics('tnt_space_index_bsize')
+
+        t.assert_items_include(metrics_vinyl_index, {
+            {index_name = 'index_1', name = 'vinyl_space_1'},
+            {index_name = 'index_2', name = 'vinyl_space_2'},
+            {index_name = 'index_3', name = 'vinyl_space_3'},
+        })
+
+        rawset(_G, 'include_vinyl_count', false)
+
+        metrics_list = get_space_metrics('tnt_space')
+
+        -- There is no "assert_items_not_include" function.
+        local count = 0
+        for _, item in pairs(metrics_list) do
+            if item.engine == 'vinyl' and item.name ~= nil and item.name:startswith('vinyl_space') then
+                count = count + 1
+            end
+        end
+        t.assert_equals(count, 0)
+
+        -- Doesn't affect vinyl indexes
+        t.assert_items_include(metrics_list, {
+            {index_name = 'index_1', name = 'vinyl_space_1'},
+            {index_name = 'index_2', name = 'vinyl_space_2'},
+            {index_name = 'index_3', name = 'vinyl_space_3'},
+        })
+    end)
 end
 
-g.test_disable_vinyl = function()
-    local metrics_list = get_space_metrics('tnt_vinyl_tuples')
+g.test_drop_indexes = function(cg)
+    cg.server:exec(function()
+        local get_space_metrics = rawget(_G, 'get_space_metrics')
 
-    t.assert_items_include(metrics_list, {
-        {engine = 'vinyl', name = 'vinyl_space_1'},
-        {engine = 'vinyl', name = 'vinyl_space_2'},
-        {engine = 'vinyl', name = 'vinyl_space_3'},
-    })
+        local metrics_list = get_space_metrics('tnt_space')
 
-    local metrics_vinyl_index = get_space_metrics('tnt_space_index_bsize')
+        t.assert_items_include(metrics_list, {
+            {index_name = 'index_1', name = 'memtx_space_1'},
+            {index_name = 'index_2', name = 'memtx_space_1'},
+            {index_name = 'index_3', name = 'memtx_space_1'},
+        })
+        t.assert_items_include(metrics_list, {
+            {index_name = 'index_1', name = 'vinyl_space_1'},
+            {index_name = 'index_2', name = 'vinyl_space_2'},
+            {index_name = 'index_3', name = 'vinyl_space_3'},
+        })
 
-    t.assert_items_include(metrics_vinyl_index, {
-        {index_name = 'index_1', name = 'vinyl_space_1'},
-        {index_name = 'index_2', name = 'vinyl_space_2'},
-        {index_name = 'index_3', name = 'vinyl_space_3'},
-    })
-
-    rawset(_G, 'include_vinyl_count', false)
-
-    metrics_list = get_space_metrics('tnt_space')
-
-    -- There is no "assert_items_not_include" function.
-    local count = 0
-    for _, item in pairs(metrics_list) do
-        if item.engine == 'vinyl' and item.name ~= nil and item.name:startswith('vinyl_space') then
-            count = count + 1
+        local count = 0
+        for _, item in pairs(metrics_list) do
+            if item.index_name ~= nil then
+                count = count + 1
+            end
         end
-    end
-    t.assert_equals(count, 0)
+        t.assert_equals(count, 18)
 
-    -- Doesn't affect vinyl indexes
-    t.assert_items_include(metrics_list, {
-        {index_name = 'index_1', name = 'vinyl_space_1'},
-        {index_name = 'index_2', name = 'vinyl_space_2'},
-        {index_name = 'index_3', name = 'vinyl_space_3'},
-    })
+        box.space.memtx_space_1.index.index_2:drop()
+        box.space.memtx_space_2.index.index_2:drop()
+        box.space.memtx_space_3.index.index_2:drop()
+
+        box.space.vinyl_space_1.index.index_3:drop()
+        box.space.vinyl_space_2.index.index_3:drop()
+        box.space.vinyl_space_3.index.index_3:drop()
+
+        metrics_list = get_space_metrics('tnt_space')
+        count = 0
+        for _, item in pairs(metrics_list) do
+            if item.index_name ~= nil then
+                count = count + 1
+            end
+        end
+        t.assert_equals(count, 12)
+
+        t.assert_items_include(metrics_list, {
+            {index_name = 'index_1', name = 'memtx_space_1'},
+            {index_name = 'index_3', name = 'memtx_space_1'},
+            {index_name = 'index_1', name = 'memtx_space_2'},
+            {index_name = 'index_3', name = 'memtx_space_2'},
+            {index_name = 'index_1', name = 'memtx_space_3'},
+            {index_name = 'index_3', name = 'memtx_space_3'},
+        })
+        t.assert_items_include(metrics_list, {
+            {index_name = 'index_1', name = 'vinyl_space_1'},
+            {index_name = 'index_2', name = 'vinyl_space_1'},
+            {index_name = 'index_1', name = 'vinyl_space_2'},
+            {index_name = 'index_2', name = 'vinyl_space_2'},
+            {index_name = 'index_1', name = 'vinyl_space_3'},
+            {index_name = 'index_2', name = 'vinyl_space_3'},
+        })
+    end)
 end
 
-g.test_drop_indexes = function()
-    local metrics_list = get_space_metrics('tnt_space')
+g.test_drop_spaces = function(cg)
+    cg.server:exec(function()
+        local get_space_metrics = rawget(_G, 'get_space_metrics')
 
-    t.assert_items_include(metrics_list, {
-        {index_name = 'index_1', name = 'memtx_space_1'},
-        {index_name = 'index_2', name = 'memtx_space_1'},
-        {index_name = 'index_3', name = 'memtx_space_1'},
-    })
-    t.assert_items_include(metrics_list, {
-        {index_name = 'index_1', name = 'vinyl_space_1'},
-        {index_name = 'index_2', name = 'vinyl_space_2'},
-        {index_name = 'index_3', name = 'vinyl_space_3'},
-    })
+        local metrics_list = get_space_metrics('tnt_space')
 
-    local count = 0
-    for _, item in pairs(metrics_list) do
-        if item.index_name ~= nil then
-            count = count + 1
+        t.assert_items_include(metrics_list, {
+            {engine = 'memtx', name = 'memtx_space_1'},
+            {engine = 'memtx', name = 'memtx_space_2'},
+            {engine = 'memtx', name = 'memtx_space_3'},
+        })
+
+        local metrics_list_vinyl = get_space_metrics('tnt_vinyl_tuples')
+
+        t.assert_items_include(metrics_list_vinyl, {
+            {engine = 'vinyl', name = 'vinyl_space_1'},
+            {engine = 'vinyl', name = 'vinyl_space_2'},
+            {engine = 'vinyl', name = 'vinyl_space_3'},
+        })
+
+        local count = 0
+        for _, item in pairs(metrics_list) do
+            if item.engine ~= nil then
+                count = count + 1
+            end
         end
-    end
-    t.assert_equals(count, 18)
-
-    box.space.memtx_space_1.index.index_2:drop()
-    box.space.memtx_space_2.index.index_2:drop()
-    box.space.memtx_space_3.index.index_2:drop()
-
-    box.space.vinyl_space_1.index.index_3:drop()
-    box.space.vinyl_space_2.index.index_3:drop()
-    box.space.vinyl_space_3.index.index_3:drop()
-
-    metrics_list = get_space_metrics('tnt_space')
-    count = 0
-    for _, item in pairs(metrics_list) do
-        if item.index_name ~= nil then
-            count = count + 1
+        for _, item in pairs(metrics_list_vinyl) do
+            if item.engine ~= nil then
+                count = count + 1
+            end
         end
-    end
-    t.assert_equals(count, 12)
+        t.assert_equals(count, 12)
 
-    t.assert_items_include(metrics_list, {
-        {index_name = 'index_1', name = 'memtx_space_1'},
-        {index_name = 'index_3', name = 'memtx_space_1'},
-        {index_name = 'index_1', name = 'memtx_space_2'},
-        {index_name = 'index_3', name = 'memtx_space_2'},
-        {index_name = 'index_1', name = 'memtx_space_3'},
-        {index_name = 'index_3', name = 'memtx_space_3'},
-    })
-    t.assert_items_include(metrics_list, {
-        {index_name = 'index_1', name = 'vinyl_space_1'},
-        {index_name = 'index_2', name = 'vinyl_space_1'},
-        {index_name = 'index_1', name = 'vinyl_space_2'},
-        {index_name = 'index_2', name = 'vinyl_space_2'},
-        {index_name = 'index_1', name = 'vinyl_space_3'},
-        {index_name = 'index_2', name = 'vinyl_space_3'},
-    })
-end
+        box.space.memtx_space_2:drop()
 
-g.test_drop_spaces = function()
-    local metrics_list = get_space_metrics('tnt_space')
+        box.space.vinyl_space_1:drop()
+        box.space.vinyl_space_3:drop()
 
-    t.assert_items_include(metrics_list, {
-        {engine = 'memtx', name = 'memtx_space_1'},
-        {engine = 'memtx', name = 'memtx_space_2'},
-        {engine = 'memtx', name = 'memtx_space_3'},
-    })
-
-    local metrics_list_vinyl = get_space_metrics('tnt_vinyl_tuples')
-
-    t.assert_items_include(metrics_list_vinyl, {
-        {engine = 'vinyl', name = 'vinyl_space_1'},
-        {engine = 'vinyl', name = 'vinyl_space_2'},
-        {engine = 'vinyl', name = 'vinyl_space_3'},
-    })
-
-    local count = 0
-    for _, item in pairs(metrics_list) do
-        if item.engine ~= nil then
-            count = count + 1
+        metrics_list = get_space_metrics('tnt_space')
+        count = 0
+        for _, item in pairs(metrics_list) do
+            if item.engine ~= nil then
+                count = count + 1
+            end
         end
-    end
-    for _, item in pairs(metrics_list_vinyl) do
-        if item.engine ~= nil then
-            count = count + 1
+        metrics_list_vinyl = get_space_metrics('tnt_vinyl_tuples')
+        for _, item in pairs(metrics_list_vinyl) do
+            if item.engine ~= nil then
+                count = count + 1
+            end
         end
-    end
-    t.assert_equals(count, 12)
+        t.assert_equals(count, 7)
 
-    box.space.memtx_space_2:drop()
+        t.assert_items_include(metrics_list, {
+            {engine = 'memtx', name = 'memtx_space_1'},
+            {engine = 'memtx', name = 'memtx_space_3'},
+        })
 
-    box.space.vinyl_space_1:drop()
-    box.space.vinyl_space_3:drop()
-
-    metrics_list = get_space_metrics('tnt_space')
-    count = 0
-    for _, item in pairs(metrics_list) do
-        if item.engine ~= nil then
-            count = count + 1
-        end
-    end
-    metrics_list_vinyl = get_space_metrics('tnt_vinyl_tuples')
-    for _, item in pairs(metrics_list_vinyl) do
-        if item.engine ~= nil then
-            count = count + 1
-        end
-    end
-    t.assert_equals(count, 7)
-
-    t.assert_items_include(metrics_list, {
-        {engine = 'memtx', name = 'memtx_space_1'},
-        {engine = 'memtx', name = 'memtx_space_3'},
-    })
-
-    t.assert_items_include(metrics_list_vinyl, {
-        {engine = 'vinyl', name = 'vinyl_space_2'},
-    })
+        t.assert_items_include(metrics_list_vinyl, {
+            {engine = 'vinyl', name = 'vinyl_space_2'},
+        })
+    end)
 end

--- a/test/tarantool/vinyl_test.lua
+++ b/test/tarantool/vinyl_test.lua
@@ -3,32 +3,36 @@ require('strict').on()
 local t = require('luatest')
 local g = t.group()
 
-local metrics = require('metrics')
-local fun = require('fun')
 local utils = require('test.utils')
 
-g.after_each(function()
-    -- Delete all collectors and global labels
-    metrics.clear()
+g.before_all(utils.create_server)
+
+g.after_all(utils.drop_server)
+
+g.before_each(function(cg)
+    cg.server:exec(function()
+        local s_vinyl = box.schema.space.create(
+            'test_space',
+            {if_not_exists = true, engine = 'vinyl'})
+        s_vinyl:create_index('pk', {if_not_exists = true})
+        require('metrics').enable_default_metrics()
+    end)
 end)
 
-g.before_each(function()
-    utils.init()
-    local s_vinyl = box.schema.space.create(
-        'test_space',
-        {if_not_exists = true, engine = 'vinyl'})
-    s_vinyl:create_index('pk', {if_not_exists = true})
-    metrics.enable_default_metrics()
-end)
+g.test_vinyl_metrics_present = function(cg)
+    cg.server:exec(function()
+        local metrics = require('metrics')
+        local fun = require('fun')
+        local utils = require('test.utils') -- luacheck: ignore 431
 
-g.test_vinyl_metrics_present = function()
-    local metrics_cnt = fun.iter(metrics.collect{invoke_callbacks = true}):filter(function(x)
-        return x.metric_name:find('tnt_vinyl')
-    end):length()
-    if utils.is_version_less(_TARANTOOL, '2.8.3')
-    and utils.is_version_greater(_TARANTOOL, '2.0.0') then
-        t.assert_equals(metrics_cnt, 19)
-    else
-        t.assert_equals(metrics_cnt, 20)
-    end
+        local metrics_cnt = fun.iter(metrics.collect{invoke_callbacks = true}):filter(function(x)
+            return x.metric_name:find('tnt_vinyl')
+        end):length()
+        if utils.is_version_less(_TARANTOOL, '2.8.3')
+        and utils.is_version_greater(_TARANTOOL, '2.0.0') then
+            t.assert_equals(metrics_cnt, 19)
+        else
+            t.assert_equals(metrics_cnt, 20)
+        end
+    end)
 end

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -2,24 +2,21 @@ local t = require('luatest')
 
 local fun = require('fun')
 local metrics = require('metrics')
-local fio = require('fio')
-local clock = require('clock')
-local fiber = require('fiber')
-local log = require('log')
 
 local utils = {}
 
-local tempdir = fio.tempdir()
-t.after_suite(function()
-    fio.rmtree(tempdir)
-end)
+function utils.create_server(g)
+    g.server = t.Server:new({
+        alias = 'myserver',
+        env = {
+            LUA_PATH = utils.LUA_PATH
+        }
+    })
+    g.server:start{wait_until_ready = true}
+end
 
-function utils.init()
-    box.cfg{
-        memtx_dir = tempdir,
-        vinyl_dir = tempdir,
-        wal_dir = tempdir,
-    }
+function utils.drop_server(g)
+    g.server:drop()
 end
 
 function utils.find_obs(metric_name, label_pairs, observations, comparator)
@@ -110,33 +107,6 @@ function utils.clear_spaces()
         end
     end
 end
-
--- Based on https://github.com/tarantool/crud/blob/5717e87e1f8a6fb852c26181524fafdbc7a472d8/test/helper.lua#L533-L544
-function utils.fflush_main_server_output(server, capture)
-    -- Sometimes we have a delay here. This hack helps to wait for the end of
-    -- the output. It shouldn't take much time.
-    local helper_msg = "metrics fflush message"
-    if server then
-        server.net_box:eval([[
-            require('log').error(...)
-        ]], {helper_msg})
-    else
-        log.error(helper_msg)
-    end
-
-    local max_wait_timeout = 10
-    local start_time = clock.monotonic()
-
-    local captured = ""
-    while (not string.find(captured, helper_msg, 1, true))
-    and (clock.monotonic() - start_time < max_wait_timeout) do
-        local captured_part = capture:flush()
-        captured = captured .. (captured_part.stdout or "") .. (captured_part.stderr or "")
-        fiber.yield()
-    end
-    return captured
-end
-
 
 -- Empty by default. Empty LUA_PATH satisfies built-in package tests.
 -- For tarantool/metrics, LUA_PATH is set up through test.helper


### PR DESCRIPTION
After this patch, complicated metrics test will run on a separate server. New tarantool/tarantool policy is to disallow box.cfg on main test instance [1].

1. https://github.com/tarantool/tarantool/pull/8709
