### PR TITLE
ci: bump version of actions/download-artifact

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -19,7 +19,7 @@ jobs:
           repository: ${{ github.repository_owner }}/metrics
 
       - name: 'Download the tarantool build artifact'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
 


### PR DESCRIPTION
Bump version of the `actions/download-artifact` action from v2 to v3.
