### PR TITLE
cfg: allow to use array-only include/exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `metrics.cfg{}` `"all"` metasection for array `include` and `exclude`
+  (`metrics.cfg{include={'all'}}` can be used instead of `metrics.cfg{include='all'}`,
+  `metrics.cfg{exclude={'all'}}` can be used instead of `metrics.cfg{include='none'}`)
+
 ## [1.0.0] - 2023-05-22
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 rpm:
 	OS=el DIST=7 packpack/packpack
 
-.rocks: metrics-scm-1.rockspec
+.rocks: metrics-scm-1.rockspec metrics/*.lua metrics/*/*.lua
 	$(TTCTL) rocks make
 	$(TTCTL) rocks install luatest # master newer than 0.5.7 required
 	$(TTCTL) rocks install luacov 0.13.0

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -325,6 +325,7 @@ Metrics functions
 
     Supported default metric names (for ``cfg.include`` and ``cfg.exclude`` tables):
 
+    *   ``all`` (metasection including all metrics)
     *   ``network``
     *   ``operations``
     *   ``system``

--- a/test/enable_default_metrics_test.lua
+++ b/test/enable_default_metrics_test.lua
@@ -82,6 +82,61 @@ local cases = {
             'tnt_info_memory_lua',
         },
     },
+    tt3_cfg_include_all = {
+        include = { 'all' },
+        exclude = nil,
+        expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+        not_expected = {},
+    },
+    tt3_cfg_exclude_all = {
+        include = nil,
+        exclude = { 'all' },
+        expected = {},
+        not_expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+    },
+    tt3_cfg_exclude_from_include_all = {
+        include = { 'all' },
+        exclude = { 'memory' },
+        expected = {
+            'tnt_info_uptime', 'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+        not_expected = {
+            'tnt_info_memory_lua',
+        },
+    },
+    tt3_cfg_include_some_exclude_all = {
+        include = { 'memory' },
+        exclude = { 'all' },
+        expected = {},
+        not_expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+    },
+    tt3_cfg_include_exclude_all = {
+        include = { 'all' },
+        exclude = { 'all' },
+        expected = {},
+        not_expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+    },
+    tt3_cfg_include_all_and_specific = {
+        include = { 'memory', 'all' },
+        exclude = nil,
+        expected = {
+            'tnt_info_uptime', 'tnt_info_memory_lua',
+            'tnt_net_sent_total', 'tnt_slab_arena_used',
+        },
+        not_expected = {},
+    },
 }
 
 local methods = {


### PR DESCRIPTION
Before this patch, a user needed to set either string or array table value to enable or disable default metrics. Tarantool 3 configuration prototype prefers more strict type system, so it was proposed to use `include={'all'}` instead of `include='all'` and `exclude={'all'}` instead of `include='none'` [1]. This patch doesn't yet forbid using existing API and not deprecates it. Defaults had also remained unchanged for now.

1. https://www.notion.so/tarantool/metrics-9fa1b8843b2341848db040f2558d8fab

I didn't forget about

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rst)
-  Rockspec and rpm spec