### PR TITLE
Replace tarantoolctl with tt

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Library includes:
 
 ```bash
 cd ${PROJECT_ROOT}
-tarantoolctl rocks install metrics
+tt rocks install metrics
 ```
 
 ## Plugins export


### PR DESCRIPTION
As a part of https://github.com/tarantool/doc/issues/3730, we need to start recommending our users to utilize tt instead of the tarantoolctl utility.