### PR TITLE
Log warning if histogram received cdata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `tnt_election_leader_idle` metric.
 
+- Histogram now logs a warning if `observe` is called with `cdata` value.
+
+### Deprecated
+
+- Using `cdata` values with `histogram:observe`.
+
 ## [1.0.0] - 2023-05-22
 ### Changed
 

--- a/metrics/collectors/histogram.lua
+++ b/metrics/collectors/histogram.lua
@@ -52,7 +52,7 @@ function Histogram:observe(num, label_pairs)
         error("Histogram observation should be a number")
     end
     if not cdata_warning_logged and type(num) == 'cdata' then
-        log.warn("Using cdata as observation in historgam " ..
+        log.error("Using cdata as observation in historgam " ..
             "can lead to unexpected results. " ..
             "That log message will be an error in the future.")
         cdata_warning_logged = true

--- a/metrics/collectors/histogram.lua
+++ b/metrics/collectors/histogram.lua
@@ -1,3 +1,5 @@
+local log = require('log')
+
 local Shared = require('metrics.collectors.shared')
 local Counter = require('metrics.collectors.counter')
 
@@ -42,10 +44,18 @@ function Histogram:set_registry(registry)
     self.bucket_collector:set_registry(registry)
 end
 
+local cdata_warning_logged = false
+
 function Histogram:observe(num, label_pairs)
     label_pairs = label_pairs or {}
     if num ~= nil and type(tonumber(num)) ~= 'number' then
         error("Histogram observation should be a number")
+    end
+    if not cdata_warning_logged and type(num) == 'cdata' then
+        log.warn("Using cdata as observation in historgam " ..
+            "can lead to unexpected results. " ..
+            "That log message will be an error in the future.")
+        cdata_warning_logged = true
     end
 
     self.count_collector:inc(1, label_pairs)


### PR DESCRIPTION
Using cdata values as historgam observations is dangerous, as described in #480. On the other hand, plenty of clients (e.g. tdg) use cdata with this collector. We decided not to throw an error here, at least for now.  

I didn't forget about

- [x] Changelog

Close #480
