### PR TITLE
Fix inconsistent metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Histogram now logs a warning if `observe` is called with `cdata` value.
 
+### Changed
+
+- Inconsistent metrics descrtiptions for memtx metrics.
+
 ### Deprecated
 
 - Using `cdata` values with `histogram:observe`.

--- a/metrics/tarantool/memtx.lua
+++ b/metrics/tarantool/memtx.lua
@@ -14,59 +14,59 @@ local function update()
     local memtx_stat = box.stat.memtx.tx()
 
     collectors_list.memtx_tnx_statements =
-        utils.set_gauge('memtx_tnx_statements', 'Maximum number of bytes used by one transaction for statements',
+        utils.set_gauge('memtx_tnx_statements', 'Number of bytes used for statements',
             memtx_stat.txn.statements.max, {kind = "max"}, nil, {default = true})
     collectors_list.memtx_tnx_statements =
-        utils.set_gauge('memtx_tnx_statements', 'Average bytes used by transactions for statements',
+        utils.set_gauge('memtx_tnx_statements', 'Number of bytes used for statements',
             memtx_stat.txn.statements.avg, {kind = "average"}, nil, {default = true})
     collectors_list.memtx_tnx_statements =
-        utils.set_gauge('memtx_tnx_statements',
-            'The number of bytes that are allocated for the statements of all current transactions',
+        utils.set_gauge('memtx_tnx_statements', 'Number of bytes used for statements',
             memtx_stat.txn.statements.total, {kind = "total"}, nil, {default = true})
 
     collectors_list.memtx_tnx_user =
         utils.set_gauge('memtx_tnx_user',
-            'The maximum number of bytes allocated by `box_txn_alloc()` function per transaction',
+            'Number of bytes allocated by `box_txn_alloc()` function per transaction',
             memtx_stat.txn.user.max, {kind = "max"}, nil, {default = true})
     collectors_list.memtx_tnx_user =
-        utils.set_gauge('memtx_tnx_user', 'Transaction average (total memory / number of all current transactions)',
+        utils.set_gauge('memtx_tnx_user',
+            'Number of bytes allocated by `box_txn_alloc()` function per transaction',
             memtx_stat.txn.user.avg, {kind = "average"}, nil, {default = true})
     collectors_list.memtx_tnx_user =
         utils.set_gauge('memtx_tnx_user',
-            'Memory allocated by the `box_txn_alloc()` function on all current transactions',
+            'Number of bytes allocated by `box_txn_alloc()` function per transaction',
             memtx_stat.txn.user.total, {kind = "total"}, nil, {default = true})
 
     collectors_list.memtx_tnx_system =
-        utils.set_gauge('memtx_tnx_system', 'The maximum number of bytes allocated by internals per transaction',
+        utils.set_gauge('memtx_tnx_system',
+            'Number of bytes allocated by internals per transaction',
             memtx_stat.txn.system.max, {kind = "max"}, nil, {default = true})
     collectors_list.memtx_tnx_system =
         utils.set_gauge('memtx_tnx_system',
-            'Average allocated memory by internals (total memory / number of all current transactions)',
+            'Number of bytes allocated by internals per transaction',
             memtx_stat.txn.system.avg, {kind = "average"}, nil, {default = true})
     collectors_list.memtx_tnx_system =
-        utils.set_gauge('memtx_tnx_system', 'Memory allocated by internals on all  transactions',
+        utils.set_gauge('memtx_tnx_system',
+            'Number of bytes allocated by internals per transaction',
             memtx_stat.txn.system.total, {kind = "total"}, nil, {default = true})
 
     collectors_list.memtx_mvcc_trackers =
-        utils.set_gauge('memtx_mvcc_trackers', 'Maximum trackers allocated per transaction',
+        utils.set_gauge('memtx_mvcc_trackers', 'Trackers allocated per transaction',
             memtx_stat.mvcc.trackers.max, {kind = "max"}, nil, {default = true})
     collectors_list.memtx_mvcc_trackers =
-        utils.set_gauge('memtx_mvcc_trackers',
-            'Average for all current transactions (total memory / number of transactions)',
+        utils.set_gauge('memtx_mvcc_trackers', 'Trackers allocated per transaction',
             memtx_stat.mvcc.trackers.avg, {kind = "average"}, nil, {default = true})
     collectors_list.memtx_mvcc_trackers =
-        utils.set_gauge('memtx_mvcc_trackers', 'Trackers are allocated in total',
+        utils.set_gauge('memtx_mvcc_trackers', 'Trackers allocated per transaction',
             memtx_stat.mvcc.trackers.total, {kind = "total"}, nil, {default = true})
 
     collectors_list.memtx_mvcc_conflicts =
-        utils.set_gauge('memtx_mvcc_conflicts', 'Maximum bytes allocated for conflicts per transaction',
+        utils.set_gauge('memtx_mvcc_conflicts', 'Bytes allocated for conflicts per transaction',
             memtx_stat.mvcc.conflicts.max, {kind = "max"}, nil, {default = true})
     collectors_list.memtx_mvcc_conflicts =
-        utils.set_gauge('memtx_mvcc_conflicts',
-            'Average for all current transactions (total memory / number of transactions)',
+        utils.set_gauge('memtx_mvcc_conflicts', 'Bytes allocated for conflicts per transaction',
             memtx_stat.mvcc.conflicts.avg, {kind = "average"}, nil, {default = true})
     collectors_list.memtx_mvcc_conflicts =
-        utils.set_gauge('memtx_mvcc_conflicts', 'Bytes allocated for conflicts in total',
+        utils.set_gauge('memtx_mvcc_conflicts', 'Bytes allocated for conflicts per transaction',
             memtx_stat.mvcc.conflicts.total, {kind = "total"}, nil, {default = true})
 
 
@@ -75,7 +75,7 @@ local function update()
             'Number of `tracking` tuples / number of tracking stories.',
             memtx_stat.mvcc.tuples.tracking.stories.count, {kind = "count"}, nil, {default = true})
     collectors_list.memtx_mvcc_tuples_tracking_stories =
-        utils.set_gauge('memtx_mvcc_tuples_tracking_stories', 'Amount of bytes used by stories `tracking` tuples',
+        utils.set_gauge('memtx_mvcc_tuples_tracking_stories', 'Number of `tracking` tuples / number of tracking stories.',
             memtx_stat.mvcc.tuples.tracking.stories.total, {kind = "total"}, nil, {default = true})
 
     collectors_list.memtx_mvcc_tuples_tracking_retained =
@@ -83,7 +83,8 @@ local function update()
             'Number of retained `tracking` tuples / number of stories',
             memtx_stat.mvcc.tuples.tracking.retained.count, {kind = "count"}, nil, {default = true})
     collectors_list.memtx_mvcc_tuples_tracking_retained =
-        utils.set_gauge('memtx_mvcc_tuples_tracking_retained', 'Amount of bytes used by retained `tracking` tuples',
+        utils.set_gauge('memtx_mvcc_tuples_tracking_retained',
+            'Number of retained `tracking` tuples / number of stories',
             memtx_stat.mvcc.tuples.tracking.retained.total, {kind = "total"}, nil, {default = true})
 
 
@@ -91,14 +92,14 @@ local function update()
         utils.set_gauge('memtx_mvcc_tuples_used_stories', 'Number of `used` tuples / number of stories',
             memtx_stat.mvcc.tuples.used.stories.count, {kind = "count"}, nil, {default = true})
     collectors_list.memtx_mvcc_tuples_used_stories =
-        utils.set_gauge('memtx_mvcc_tuples_used_stories', 'Amount of bytes used by stories ``used`` tuples',
+        utils.set_gauge('memtx_mvcc_tuples_used_stories', 'Number of `used` tuples / number of stories',
             memtx_stat.mvcc.tuples.used.stories.total, {kind = "total"}, nil, {default = true})
 
     collectors_list.memtx_mvcc_tuples_used_retained =
         utils.set_gauge('memtx_mvcc_tuples_used_retained', 'Number of retained `used` tuples / number of stories',
             memtx_stat.mvcc.tuples.used.retained.count, {kind = "count"}, nil, {default = true})
     collectors_list.memtx_mvcc_tuples_used_retained =
-        utils.set_gauge('memtx_mvcc_tuples_used_retained', 'Amount of bytes used by retained `used` tuples',
+        utils.set_gauge('memtx_mvcc_tuples_used_retained', 'Number of retained `used` tuples / number of stories',
             memtx_stat.mvcc.tuples.used.retained.total, {kind = "total"}, nil, {default = true})
 
 
@@ -108,7 +109,7 @@ local function update()
             memtx_stat.mvcc.tuples.read_view.stories.count, {kind = "count"}, nil, {default = true})
     collectors_list.memtx_mvcc_tuples_read_view_stories =
         utils.set_gauge('memtx_mvcc_tuples_read_view_stories',
-            'Amount of bytes used by stories `read_view` tuples',
+            'Number of `read_view` tuples / number of stories',
             memtx_stat.mvcc.tuples.read_view.stories.total, {kind = "total"}, nil, {default = true})
 
     collectors_list.memtx_mvcc_tuples_read_view_retained =
@@ -117,7 +118,7 @@ local function update()
             memtx_stat.mvcc.tuples.read_view.retained.count, {kind = "count"}, nil, {default = true})
     collectors_list.memtx_mvcc_tuples_read_view_retained =
         utils.set_gauge('memtx_mvcc_tuples_read_view_retained',
-            'Amount of bytes used by retained `read_view` tuples',
+            'Number of retained `read_view` tuples / number of stories',
             memtx_stat.mvcc.tuples.read_view.retained.total, {kind = "total"}, nil, {default = true})
 
 end


### PR DESCRIPTION
Found out that several memtx metrics try to set different descriptions to the same metric.

I didn't forget about

- [ ] Changelog
