### PR TITLE
Fix replicas metrics for tarantool raft

### DIFF
--- a/metrics/tarantool/replicas.lua
+++ b/metrics/tarantool/replicas.lua
@@ -9,7 +9,7 @@ local function update_replicas_metrics()
 
     local current_box_info = box.info()
 
-    if box.cfg.read_only then
+    if current_box_info.ro then
         for k, v in pairs(current_box_info.vclock) do
             local replication_info = current_box_info.replication[k]
             if replication_info then


### PR DESCRIPTION
Change replica detection from using function `box.cfg.read_only` to `box.info.ro`. 

Function `box.info.ro` can be true in case of autofailover-leader change, but `box.cfg.read_only` may not.

Reference:
1. Lua-function `box.info.ro` calls C-function `box_is_ro`: [info.c#L349](https://github.com/tarantool/tarantool/blob/cfd4bf4685de6ee2dced133519ce34f71e3bb71b/src/box/lua/info.c#L349).
2. C-function `box_is_ro` uses variable `is_ro_summary`: [box.cc#L551](https://github.com/tarantool/tarantool/blob/master/src/box/box.cc#L551).
3. Variable `is_ro_summary` is a sum of value `box.cfg.read_only`, orphan status and autofailover-leader status: [box.cc#L360](https://github.com/tarantool/tarantool/blob/master/src/box/box.cc#L360).
4. Variable `is_ro_summary` is recomputed on autofailover-leader change: [raft.c#L205](https://github.com/tarantool/tarantool/blob/master/src/box/raft.c#L205) 