### PR TITLE
Optimize label handling with predefined label keys in counter/gauge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `tnt_cartridge_config_applied` metric.
+- New optional ``label_keys`` parameter for ``counter()`` and ``gauge()`` metrics.
 
 ## [1.3.1] - 2025-02-24
 

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -33,14 +33,18 @@ currently running processes. Use a :ref:`gauge <metrics-api_reference-gauge>` ty
 
 The design is based on the `Prometheus counter <https://prometheus.io/docs/concepts/metric_types/#counter>`__.
 
-..  function:: counter(name [, help, metainfo])
+..  function:: counter(name [, help, metainfo, label_keys])
 
     Register a new counter.
 
     :param string name: collector name. Must be unique.
     :param string help: collector description.
     :param table metainfo: collector metainfo.
+    :param table label_keys: predefined label keys to optimize performance.
+        When specified, only these keys can be used in ``label_pairs``.
+
     :return: A counter object.
+
     :rtype: counter_obj
 
 ..  class:: counter_obj
@@ -102,13 +106,15 @@ it might be used for the values that can go up or down, for example, the number 
 
 The design is based on the `Prometheus gauge <https://prometheus.io/docs/concepts/metric_types/#gauge>`__.
 
-..  function:: gauge(name [, help, metainfo])
+..  function:: gauge(name [, help, metainfo, label_keys])
 
     Register a new gauge.
 
     :param string name: collector name. Must be unique.
     :param string help: collector description.
     :param table metainfo: collector metainfo.
+    :param table label_keys: predefined label keys to optimize performance.
+        When specified, only these keys can be used in ``label_pairs``.
 
     :return: A gauge object.
 

--- a/metrics/api.lua
+++ b/metrics/api.lua
@@ -65,16 +65,16 @@ local function clear()
     registry:clear()
 end
 
-local function counter(name, help, metainfo)
-    checks('string', '?string', '?table')
+local function counter(name, help, metainfo, label_keys)
+    checks('string', '?string', '?table', '?table')
 
-    return registry:find_or_create(Counter, name, help, metainfo)
+    return registry:find_or_create(Counter, name, help, metainfo, label_keys)
 end
 
-local function gauge(name, help, metainfo)
-    checks('string', '?string', '?table')
+local function gauge(name, help, metainfo, label_keys)
+    checks('string', '?string', '?table', '?table')
 
-    return registry:find_or_create(Gauge, name, help, metainfo)
+    return registry:find_or_create(Gauge, name, help, metainfo, label_keys)
 end
 
 local function histogram(name, help, buckets, metainfo)


### PR DESCRIPTION
This change adds support for predefined label keys in `counter` and `gauge` metric constructors, optimizing label processing.

Changes:
* Add optional `label_keys` table to `counter()` and `gauge()` initialization
* Replace dynamic label sorting with direct key generation when `label_keys` are provided, eliminating unnecessary processing overhead

Dynamic labels still supported when `label_keys` is omitted.

Closes TNTP-3453