### PR TITLE
Add tnt_cartridge_config_applied metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `tnt_cartridge_config_applied` metric
 
 ## [1.3.1] - 2025-02-24
 

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -564,6 +564,7 @@ Metrics functions
     *   ``luajit``
     *   ``cartridge_issues``
     *   ``cartridge_failover``
+    *   ``cartridge_config``
     *   ``clock``
     *   ``event_loop``
     *   ``config``

--- a/doc/monitoring/metrics_reference.rst
+++ b/doc/monitoring/metrics_reference.rst
@@ -414,6 +414,9 @@ Cartridge
         *   -   ``tnt_cartridge_failover_trigger_total``
             -   Count of failover triggers in cluster.
 
+        *   -   ``tnt_cartridge_config_applied``
+            -   Whether the Cartridge configuration was successfully applied (1 if applied, 0 otherwise).
+
 ..  _metrics-reference-luajit:
 
 LuaJIT metrics

--- a/metrics/cartridge/config.lua
+++ b/metrics/cartridge/config.lua
@@ -1,0 +1,32 @@
+local utils = require('metrics.utils')
+local collectors_list = {}
+local vars = nil
+
+local function update()
+    if vars == nil then
+        local is_cartridge = pcall(require, 'cartridge')
+        if not is_cartridge then
+            return
+        end
+
+        vars = require('cartridge.vars').new('cartridge.twophase')
+    end
+
+    local config_applied = vars.config_applied
+    if config_applied ~= nil then
+        collectors_list.config_applied =
+            utils.set_gauge(
+                'cartridge_config_applied',
+                'Whether the Cartridge configuration was successfully applied',
+                config_applied and 1 or 0,
+                nil,
+                nil,
+                {default = true}
+            )
+    end
+end
+
+return {
+    update = update,
+    list = collectors_list,
+}

--- a/metrics/tarantool.lua
+++ b/metrics/tarantool.lua
@@ -22,6 +22,7 @@ local default_metrics = {
     luajit              = require('metrics.tarantool.luajit'),
     cartridge_issues    = require('metrics.cartridge.issues'),
     cartridge_failover  = require('metrics.cartridge.failover'),
+    cartridge_config    = require('metrics.cartridge.config'),
     clock               = require('metrics.tarantool.clock'),
     event_loop          = require('metrics.tarantool.event_loop'),
     config              = require('metrics.tarantool.config'),


### PR DESCRIPTION
Added a new metric `tnt_cartridge_config_applied` to track whether the clusterwide config was successfully applied. It reports `1` if the config was successfully applied and `0` otherwise.

Depends on the cartridge's [config_applied var](https://github.com/tarantool/cartridge/pull/2341).

Closes TNTP-3354
