### PR TITLE
Add tnt_cartridge_config_checksum metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `tnt_cartridge_config_checksum` metric.
+
 ### Changed
 
 ### Fixed

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -570,6 +570,7 @@ Metrics functions
     *   ``luajit``
     *   ``cartridge_issues``
     *   ``cartridge_failover``
+    *   ``cartridge_config``
     *   ``clock``
     *   ``event_loop``
     *   ``config``

--- a/doc/monitoring/metrics_reference.rst
+++ b/doc/monitoring/metrics_reference.rst
@@ -414,6 +414,10 @@ Cartridge
         *   -   ``tnt_cartridge_failover_trigger_total``
             -   Count of failover triggers in cluster.
 
+        *   -   ``tnt_cartridge_config_checksum``
+            -   Cartridge configuration checksum on the instance.
+                Can be used to detect configuration divergence across cluster nodes.
+
 ..  _metrics-reference-luajit:
 
 LuaJIT metrics

--- a/metrics/cartridge/config.lua
+++ b/metrics/cartridge/config.lua
@@ -1,0 +1,28 @@
+local utils = require('metrics.utils')
+local collectors_list = {}
+
+local function update()
+    local is_cartridge = pcall(require, 'cartridge')
+    if not is_cartridge then
+        return
+    end
+
+    local confapplier = require('cartridge.confapplier')
+    local clusterwide_config = confapplier.get_active_config()
+    if clusterwide_config ~= nil then
+        collectors_list.config_checksum =
+            utils.set_gauge(
+                'cartridge_config_checksum',
+                'Cartridge configuration checksum on the instance',
+                clusterwide_config:get_checksum(),
+                nil,
+                nil,
+                {default = true}
+            )
+    end
+end
+
+return {
+    update = update,
+    list = collectors_list,
+}

--- a/metrics/tarantool.lua
+++ b/metrics/tarantool.lua
@@ -22,6 +22,7 @@ local default_metrics = {
     luajit              = require('metrics.tarantool.luajit'),
     cartridge_issues    = require('metrics.cartridge.issues'),
     cartridge_failover  = require('metrics.cartridge.failover'),
+    cartridge_config    = require('metrics.cartridge.config'),
     clock               = require('metrics.tarantool.clock'),
     event_loop          = require('metrics.tarantool.event_loop'),
     config              = require('metrics.tarantool.config'),


### PR DESCRIPTION
This PR adds `tnt_cartridge_config_checksum` metric to help detect configuration divergence across cluster nodes.

- [x] Tests
- [x] Changelog
- [x] Documentation (README and rst)
- [ ] Rockspec and rpm spec

Closes TNTP-3819
