### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `tnt_cartridge_config_checksum` metric.
-
 ### Changed
 
 ### Fixed
+
+# [1.5.0] - 2025-08-13
+
+### Added
+
+- `tnt_cartridge_config_checksum` metric.
 
 ### Removed
 


### PR DESCRIPTION
### Added

- `tnt_cartridge_config_checksum` metric.

### Removed

- `tnt_cartridge_config_applied` metric that only reflected local node state.