### PR TITLE
process: virtual memory size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `tnt_memory` metric.
+- `tnt_memory_virt` metric.
 
 ### Changed
 

--- a/doc/monitoring/metrics_reference.rst
+++ b/doc/monitoring/metrics_reference.rst
@@ -41,7 +41,9 @@ These metrics can be used to monitor instance CPU and RAM usage.
         *   -   ``tnt_cpu_system_time``
             -   Tarantool CPU system time.
         *   -   ``tnt_memory``
-            -   Total number of bytes used by Tarantool instance.
+            -   Resident memory size in bytes used by Tarantool instance.
+        *   -   ``tnt_memory_virt``
+            -   Virtual memory size in bytes used by Tarantool instance (available on Linux).
 
 .. _metrics-reference-instance:
 

--- a/metrics/tarantool/memory.lua
+++ b/metrics/tarantool/memory.lua
@@ -29,10 +29,14 @@ local function update_memory_metrics()
     end
 
     local memory_stat = 0
+    local memory_virt_stat = 0
 
     if jit.os == 'Linux' then
         local data = psutils.get_process_stats()
-        memory_stat = data.rss * sys_mem_page_size
+        if data then
+            memory_stat = data.rss * sys_mem_page_size
+            memory_virt_stat = data.vsize
+        end
     else
         --[[memory]]
         -- Skip `memory_box.data` cause in fact this is `memory_box.index`
@@ -70,6 +74,10 @@ local function update_memory_metrics()
     --[[metric]]
     collectors_list.memory_stat_usage = utils.set_gauge('memory',
         'Tarantool instance memory usage', memory_stat,
+        nil, nil, {default = true})
+
+    collectors_list.memory_virt_stat_usage = utils.set_gauge('memory_virt',
+        'Tarantool instance virtual memory usage', memory_virt_stat,
         nil, nil, {default = true})
 end
 

--- a/test/tarantool/memory_metrics_test.lua
+++ b/test/tarantool/memory_metrics_test.lua
@@ -36,5 +36,9 @@ g.test_instance_metrics = function(cg)
         local memory_metric = utils.find_metric('tnt_memory', default_metrics)
         t.assert(memory_metric)
         t.assert_gt(memory_metric[1].value, 0)
+
+        local memory_virt_metric = utils.find_metric('tnt_memory_virt', default_metrics)
+        t.assert(memory_virt_metric)
+        t.assert_gt(memory_virt_metric[1].value, 0)
     end)
 end


### PR DESCRIPTION
This patch adds new `tnt_memory_virt` metric (available on Linux).

Closes #TNTP-4362
