### PR TITLE
test: make memory metrics test portable

### DIFF
--- a/test/tarantool/memory_metrics_test.lua
+++ b/test/tarantool/memory_metrics_test.lua
@@ -24,6 +24,7 @@ g.after_each(function(cg)
 end)
 
 g.test_instance_metrics = function(cg)
+    t.skip_if(jit.os ~= 'Linux', 'Linux is the only supported platform')
     cg.server:exec(function()
         local metrics = require('metrics')
         local memory = require('metrics.tarantool.memory')


### PR DESCRIPTION
This patch makes `tarantool/memory_metrics_test.lua` portable across platforms.

Part of tarantool/tarantool#12559
