### PR TITLE
api: add selector-based filtering for custom metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `metrics.namespace()` and `metrics.set_filter()` to mark custom
+  collectors/callbacks with selectors and filter them at collection time.
+
 ### Changed
 
 ### Fixed

--- a/doc/monitoring/api_reference.rst
+++ b/doc/monitoring/api_reference.rst
@@ -540,11 +540,12 @@ Metrics functions
     :param table config: module configuration options:
 
       * ``cfg.include`` (string/table, default ``'all'``): ``'all`` to enable all
-        supported default metrics, ``'none'`` to disable all default metrics,
-        table with names of the default metrics to enable a specific set of metrics.
-      * ``cfg.exclude`` (table, default ``{}``): table containing the names of
-        the default metrics that you want to disable. Has higher priority
-        than ``cfg.include``.
+        supported default metrics and custom metrics, ``'none'`` to disable
+        all metrics, or a table with default metric names and custom selectors
+        to enable.
+      * ``cfg.exclude`` (table, default ``{}``): table containing default metric
+        names and custom selectors that you want to disable. Has higher
+        priority than ``cfg.include``.
       * ``cfg.labels`` (table, default ``{}``): table containing label names as
         string keys, label values as values.
 
@@ -579,6 +580,26 @@ Metrics functions
     See :ref:`metrics reference <metrics-reference>` for details.
     All metric collectors from the collection have ``metainfo.default = true``.
 
+    Other strings in ``cfg.include`` and ``cfg.exclude`` are treated as custom
+    metric selectors. A selector matches either exactly or by dot prefix. For
+    example, ``roles.crud-router`` matches
+    ``roles.crud-router.request_count``.
+
+    **Example:**
+
+    ..  code-block:: lua
+
+        local metrics = require('metrics')
+
+        local crud = metrics.namespace('roles.crud-router')
+        crud:gauge('crud_requests'):set(1)
+        crud:gauge('crud_errors'):set(1)
+
+        metrics.cfg{
+            include = {'info', 'roles.crud-router'},
+            exclude = {'roles.crud-router.crud_errors'},
+        }
+
     ``cfg.labels`` are the global labels to be added to every observation.
 
     Global labels are applied only to metric collection. They have no effect
@@ -600,6 +621,42 @@ Metrics functions
 ..  function:: set_global_labels(label_pairs)
 
     Same as ``metrics.cfg{labels=label_pairs}``.
+
+..  function:: set_filter([include, exclude])
+
+    Set a runtime filter for collectors and callbacks by metric selectors.
+
+    :param string/table include: ``'all'`` to include everything,
+        ``'none'`` to disable everything, or a table with selector objects
+        to include. The default is ``'all'``.
+    :param string/table exclude: ``'all'`` to exclude everything or a table
+        with selector objects to exclude. Has higher priority than ``include``.
+
+    A selector matches either exactly or by dot prefix. For example,
+    ``roles.crud-router`` matches ``roles.crud-router.request_count``.
+
+..  function:: namespace(selector)
+
+    Create a namespace object that marks collectors and callbacks with
+    selectors derived from ``selector``.
+
+    **Example:**
+
+    ..  code-block:: lua
+
+        local metrics = require('metrics')
+        local ns = metrics.namespace('roles.crud-router')
+
+        local requests = ns:counter('crud_router_requests_total')
+        local in_flight = ns:gauge('crud_router_requests_in_flight')
+
+        metrics.register_callback(function()
+            in_flight:set(get_in_flight_requests())
+        end, {selector = 'roles.crud-router'})
+
+        metrics.set_filter('all', {
+            {selector = 'roles.crud-router'},
+        })
 
 ..  function:: collect([opts])
 

--- a/metrics/api.lua
+++ b/metrics/api.lua
@@ -12,17 +12,24 @@ local Summary = require('metrics.collectors.summary')
 local registry = rawget(_G, '__metrics_registry')
 if not registry then
     registry = Registry.new()
+else
+    setmetatable(registry, Registry)
+    if registry.filter == nil then
+        registry:reset_filter()
+    end
 end
 registry.callbacks = {}
 
 rawset(_G, '__metrics_registry', registry)
 
 local function collectors()
-    return registry.collectors
+    return registry:filtered_collectors()
 end
 
-local function register_callback(...)
-    return registry:register_callback(...)
+local function register_callback(callback, metainfo)
+    checks('function', '?table')
+
+    return registry:register_callback(callback, metainfo)
 end
 
 local function unregister_callback(...)
@@ -48,7 +55,7 @@ local function collect(opts)
     end
 
     local result = {}
-    for _, collector in pairs(registry.collectors) do
+    for _, collector in pairs(registry:filtered_collectors()) do
         if opts.default_only then
             if collector.metainfo.default then
                 get_collector_values(collector, result)
@@ -125,6 +132,60 @@ local function set_global_labels(label_pairs)
     registry:set_labels(label_pairs)
 end
 
+local function set_filter(include, exclude)
+    checks('?string|table', '?string|table')
+
+    registry:set_filter(include, exclude)
+end
+
+local Namespace = {}
+Namespace.__index = Namespace
+
+local function namespace_metainfo(self, name, metainfo)
+    local res = table.copy(metainfo) or {}
+    res.selector = res.selector or (self.selector .. '.' .. name)
+    return res
+end
+
+function Namespace:counter(name, help, metainfo, label_keys)
+    return counter(name, help, namespace_metainfo(self, name, metainfo),
+                   label_keys)
+end
+
+function Namespace:gauge(name, help, metainfo, label_keys)
+    return gauge(name, help, namespace_metainfo(self, name, metainfo),
+                 label_keys)
+end
+
+function Namespace:histogram(name, help, buckets, metainfo)
+    return histogram(name, help, buckets,
+                     namespace_metainfo(self, name, metainfo))
+end
+
+function Namespace:summary(name, help, objectives, params, metainfo)
+    return summary(name, help, objectives, params,
+                   namespace_metainfo(self, name, metainfo))
+end
+
+function Namespace:register_callback(callback, metainfo)
+    local res = table.copy(metainfo) or {}
+    res.selector = res.selector or self.selector
+    return register_callback(callback, res)
+end
+
+function Namespace.unregister_callback(_, callback)
+    return unregister_callback(callback)
+end
+
+local function namespace(selector)
+    checks('string')
+    if selector == '' then
+        error('Metric namespace selector must not be empty')
+    end
+
+    return setmetatable({selector = selector}, Namespace)
+end
+
 return {
     registry = registry,
     collectors = collectors,
@@ -140,4 +201,6 @@ return {
     unregister_callback = unregister_callback,
     invoke_callbacks = invoke_callbacks,
     set_global_labels = set_global_labels,
+    set_filter = set_filter,
+    namespace = namespace,
 }

--- a/metrics/cfg.lua
+++ b/metrics/cfg.lua
@@ -7,6 +7,40 @@ local const = require('metrics.const')
 local stash = require('metrics.stash')
 local metrics_tarantool = require('metrics.tarantool')
 
+-- Split a metrics.cfg include/exclude side into two parts: built-in metric
+-- groups for metrics.tarantool and custom selectors for the registry filter.
+local function split_metric_groups_and_selectors(values, default_value,
+                                                 empty_default,
+                                                 empty_selectors)
+    values = values or default_value
+
+    if type(values) == 'string' then
+        return values, values
+    end
+
+    -- Built-in metric groups are handled by metrics.tarantool, while unknown
+    -- values are treated as custom selectors and passed to the registry filter.
+    local default_metrics = {}
+    local custom_selectors = {}
+    for _, value in ipairs(values) do
+        if value == const.ALL or metrics_tarantool.is_default_metric(value) then
+            table.insert(default_metrics, value)
+        else
+            table.insert(custom_selectors, {selector = value})
+        end
+    end
+
+    if next(default_metrics) == nil then
+        default_metrics = empty_default
+    end
+
+    if next(custom_selectors) == nil then
+        custom_selectors = empty_selectors
+    end
+
+    return default_metrics, custom_selectors
+end
+
 local function set_defaults_if_empty(cfg)
     if cfg.include == nil then
         cfg.include = const.ALL
@@ -37,7 +71,14 @@ local function configure(cfg, opts)
     end
 
 
-    metrics_tarantool.enable_v2(opts.include, opts.exclude)
+    local default_include, selector_include =
+        split_metric_groups_and_selectors(opts.include, const.ALL, const.NONE,
+                                          const.ALL)
+    local default_exclude, selector_exclude =
+        split_metric_groups_and_selectors(opts.exclude, {}, {}, {})
+
+    metrics_tarantool.enable_v2(default_include, default_exclude)
+    metrics_api.set_filter(selector_include, selector_exclude)
     metrics_api.set_global_labels(opts.labels)
 
     rawset(cfg, 'include', opts.include)

--- a/metrics/init.lua
+++ b/metrics/init.lua
@@ -23,10 +23,12 @@ return setmetatable({
 
     clear = api.clear,
     collectors = api.collectors,
+    namespace = api.namespace,
     register_callback = api.register_callback,
     unregister_callback = api.unregister_callback,
     invoke_callbacks = api.invoke_callbacks,
     set_global_labels = api.set_global_labels,
+    set_filter = api.set_filter,
     enable_default_metrics = tarantool.enable,
     cfg = cfg.cfg,
     http_middleware = http_middleware,

--- a/metrics/registry.lua
+++ b/metrics/registry.lua
@@ -12,6 +12,16 @@ function Registry:clear()
     self.collectors = {}
     self.callbacks = {}
     self.label_pairs = {}
+    self:reset_filter()
+end
+
+function Registry:reset_filter()
+    self.filter = {
+        include_all = true,
+        include = {},
+        exclude_all = false,
+        exclude = {},
+    }
 end
 
 function Registry:find(kind, name)
@@ -42,15 +52,78 @@ function Registry:unregister(collector)
     self.collectors[collector.name .. collector.kind] = nil
 end
 
+local function has_prefix(s, prefix)
+    return s:startswith(prefix .. '.')
+end
+
+local function selector_matches(selector, rules)
+    if selector == nil then
+        return false
+    end
+
+    for _, rule in ipairs(rules) do
+        if selector == rule or has_prefix(selector, rule) then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function item_selector(item)
+    if item == nil then
+        return nil
+    end
+
+    local metainfo = item.metainfo or item
+    return metainfo.selector or item.name
+end
+
+function Registry:is_enabled(item)
+    local filter = self.filter
+    local metainfo = item and (item.metainfo or item)
+    if metainfo and metainfo.default then
+        return not filter.exclude_all
+    end
+
+    local selector = item_selector(item)
+
+    local included = filter.include_all or
+                     selector_matches(selector, filter.include)
+    if not included then
+        return false
+    end
+
+    if filter.exclude_all or selector_matches(selector, filter.exclude) then
+        return false
+    end
+
+    return true
+end
+
+function Registry:filtered_collectors()
+    local collectors = {}
+
+    for key, collector in pairs(self.collectors) do
+        if self:is_enabled(collector) then
+            collectors[key] = collector
+        end
+    end
+
+    return collectors
+end
+
 function Registry:invoke_callbacks()
-    for registered_callback, _ in pairs(self.callbacks) do
-        registered_callback()
+    for registered_callback, metainfo in pairs(self.callbacks) do
+        if self:is_enabled(metainfo) then
+            registered_callback()
+        end
     end
 end
 
 function Registry:collect()
     local result = {}
-    for _, collector in pairs(self.collectors) do
+    for _, collector in pairs(self:filtered_collectors()) do
         for _, obs in ipairs(collector:collect()) do
             table.insert(result, obs)
         end
@@ -58,8 +131,8 @@ function Registry:collect()
     return result
 end
 
-function Registry:register_callback(callback)
-    self.callbacks[callback] = true
+function Registry:register_callback(callback, metainfo)
+    self.callbacks[callback] = table.copy(metainfo) or {}
 end
 
 function Registry:unregister_callback(callback)
@@ -68,6 +141,60 @@ end
 
 function Registry:set_labels(label_pairs)
     self.label_pairs = table.copy(label_pairs)
+end
+
+local function normalize_filter_side(value, default)
+    if value == nil then
+        return default
+    end
+
+    if type(value) == 'string' then
+        if value ~= 'all' and value ~= 'none' then
+            error("Metric selector filter string must be 'all' or 'none'")
+        end
+        return {
+            all = value == 'all',
+            selectors = {},
+        }
+    end
+
+    if type(value) ~= 'table' then
+        error("Metric selector filter must be 'all', 'none', or an array of " ..
+              "selector objects")
+    end
+
+    local selectors = {}
+    for _, item in ipairs(value) do
+        if type(item) ~= 'table' or type(item.selector) ~= 'string' or
+           item.selector == '' then
+            error('Metric selector filter item must be a table with a ' ..
+                  'non-empty selector field')
+        end
+        table.insert(selectors, item.selector)
+    end
+
+    return {
+        all = false,
+        selectors = selectors,
+    }
+end
+
+function Registry:set_filter(include, exclude)
+    local include_filter = normalize_filter_side(include, {
+        all = true,
+        selectors = {},
+    })
+    local exclude_filter = normalize_filter_side(exclude, {
+        all = false,
+        selectors = {},
+    })
+
+    self.filter = {
+        include_all = include_filter.all,
+        include = include_filter.selectors,
+        exclude_all = exclude_filter.all,
+        exclude = exclude_filter.selectors,
+    }
 end
 
 return Registry

--- a/metrics/tarantool.lua
+++ b/metrics/tarantool.lua
@@ -35,6 +35,10 @@ for name, _ in pairs(default_metrics) do
     all_metrics_map[name] = true
 end
 
+local function is_default_metric(name)
+    return default_metrics[name] ~= nil
+end
+
 local function check_metrics_name(name, raise_if_unknown)
     if default_metrics[name] == nil then
         if raise_if_unknown then
@@ -79,7 +83,7 @@ local function enable_impl(include, exclude, raise_if_unknown)
 
     for name, value in pairs(default_metrics) do
         if include_map[name] then
-            metrics_api.register_callback(value.update)
+            metrics_api.register_callback(value.update, {default = true})
         else
             metrics_api.unregister_callback(value.update)
             utils.delete_collectors(value.list)
@@ -110,4 +114,5 @@ end
 return {
     enable = enable,
     enable_v2 = enable_v2,
+    is_default_metric = is_default_metric,
 }

--- a/test/cfg_test.lua
+++ b/test/cfg_test.lua
@@ -195,6 +195,84 @@ group.test_include_with_exclude = function(g)
     end)
 end
 
+group.test_custom_selectors = function(g)
+    g.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
+        local crud = metrics.namespace('roles.crud-router')
+        local queue = metrics.namespace('roles.queue')
+
+        metrics.cfg{
+            include = {'info', 'roles.crud-router'},
+            exclude = {'roles.crud-router.errors'},
+        }
+
+        crud:gauge('crud_requests'):set(1)
+        crud:gauge('errors'):set(1)
+        queue:gauge('queue_requests'):set(1)
+
+        local observations = metrics.collect{invoke_callbacks = true}
+        t.assert_not_equals(utils.find_metric('tnt_info_uptime',
+                                             observations), nil)
+        t.assert_not_equals(utils.find_metric('crud_requests', observations),
+                            nil)
+        t.assert_equals(utils.find_metric('errors', observations), nil)
+        t.assert_equals(utils.find_metric('queue_requests', observations), nil)
+    end)
+end
+
+group.test_custom_selectors_reconfiguration = function(g)
+    g.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
+        local crud = metrics.namespace('roles.crud-router')
+        local queue = metrics.namespace('roles.queue')
+
+        crud:gauge('crud_requests'):set(1)
+        queue:gauge('queue_requests'):set(1)
+
+        metrics.cfg{
+            include = {'roles.crud-router'},
+            exclude = {},
+        }
+
+        local observations = metrics.collect{invoke_callbacks = true}
+        t.assert_not_equals(utils.find_metric('crud_requests', observations),
+                            nil)
+        t.assert_equals(utils.find_metric('queue_requests', observations), nil)
+
+        metrics.cfg{
+            include = {'roles.queue'},
+            exclude = {},
+        }
+
+        observations = metrics.collect{invoke_callbacks = true}
+        t.assert_equals(utils.find_metric('crud_requests', observations), nil)
+        t.assert_not_equals(utils.find_metric('queue_requests', observations),
+                            nil)
+    end)
+end
+
+group.test_cfg_clean_user_metrics = function(g)
+    g.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
+
+        local my_gauge = metrics.gauge('my_custom_metric',
+                                       'My custom metric')
+        my_gauge:set(42)
+
+        metrics.cfg{
+            include = {'info'},
+            exclude = {},
+        }
+
+        local observations = metrics.collect{invoke_callbacks = true}
+        t.assert_not_equals(utils.find_metric('my_custom_metric',
+                                             observations), nil)
+    end)
+end
+
 group.test_include_none = function(g)
     g.server:exec(function()
         local metrics = require('metrics')

--- a/test/metrics_test.lua
+++ b/test/metrics_test.lua
@@ -169,6 +169,44 @@ g.test_hotreload_remove_callbacks = function(cg)
     end)
 end
 
+g.test_hotreload_old_registry_gets_filter = function(cg)
+    cg.server:exec(function()
+        local previous_registry = rawget(_G, '__metrics_registry')
+        local previous_metrics_api = package.loaded['metrics.api']
+        local old_registry = {
+            collectors = {},
+            callbacks = {},
+            label_pairs = {},
+        }
+
+        rawset(_G, '__metrics_registry', old_registry)
+        package.loaded['metrics.api'] = nil
+
+        local metrics_api = require('metrics.api')
+        local registry = rawget(_G, '__metrics_registry')
+
+        t.assert_equals(registry, old_registry)
+        t.assert_not_equals(registry.filter, nil)
+        t.assert_equals(registry.filter, {
+            include_all = true,
+            include = {},
+            exclude_all = false,
+            exclude = {},
+        })
+
+        metrics_api.set_filter({{selector = 'roles.crud-router'}}, {})
+        t.assert_equals(registry.filter, {
+            include_all = false,
+            include = {'roles.crud-router'},
+            exclude_all = false,
+            exclude = {},
+        })
+
+        rawset(_G, '__metrics_registry', previous_registry)
+        package.loaded['metrics.api'] = previous_metrics_api
+    end)
+end
+
 local collect_invoke_callbacks_cases = {
     default = {
         args = nil,
@@ -201,6 +239,134 @@ for name, case in pairs(collect_invoke_callbacks_cases) do
         local obs = utils.find_obs('mycounter', {}, observations)
         t.assert_equals(obs.value, case.value)
     end
+end
+
+g.test_filter_custom_collectors = function()
+    local crud = metrics.namespace('roles.crud-router')
+    local queue = metrics.namespace('roles.queue')
+
+    local crud_requests = crud:gauge('crud_requests')
+    crud_requests:set(1)
+    queue:gauge('queue_requests'):set(2)
+    metrics.gauge('ungrouped_requests'):set(3)
+
+    t.assert_equals(crud_requests.metainfo, {
+        selector = 'roles.crud-router.crud_requests',
+    })
+
+    metrics.set_filter({{selector = 'roles.crud-router'}}, {})
+
+    local observations = metrics.collect()
+    t.assert_not_equals(utils.find_metric('crud_requests', observations), nil)
+    t.assert_equals(utils.find_metric('queue_requests', observations), nil)
+    t.assert_equals(utils.find_metric('ungrouped_requests', observations), nil)
+end
+
+g.test_filter_custom_collectors_exclude_has_priority = function()
+    local crud = metrics.namespace('roles.crud-router')
+
+    crud:gauge('crud_requests'):set(1)
+    crud:gauge('crud_errors'):set(2)
+
+    metrics.set_filter({{selector = 'roles.crud-router'}},
+                       {{selector = 'roles.crud-router.crud_errors'}})
+
+    local observations = metrics.collect()
+    t.assert_not_equals(utils.find_metric('crud_requests', observations), nil)
+    t.assert_equals(utils.find_metric('crud_errors', observations), nil)
+end
+
+g.test_filter_can_be_reconfigured = function()
+    local crud = metrics.namespace('roles.crud-router')
+    local queue = metrics.namespace('roles.queue')
+
+    crud:gauge('crud_requests'):set(1)
+    queue:gauge('queue_requests'):set(1)
+
+    metrics.set_filter({{selector = 'roles.crud-router'}}, {})
+    local observations = metrics.collect()
+    t.assert_not_equals(utils.find_metric('crud_requests', observations), nil)
+    t.assert_equals(utils.find_metric('queue_requests', observations), nil)
+
+    metrics.set_filter({{selector = 'roles.queue'}}, {})
+    observations = metrics.collect()
+    t.assert_equals(utils.find_metric('crud_requests', observations), nil)
+    t.assert_not_equals(utils.find_metric('queue_requests', observations), nil)
+
+    metrics.set_filter('all', {})
+    observations = metrics.collect()
+    t.assert_not_equals(utils.find_metric('crud_requests', observations), nil)
+    t.assert_not_equals(utils.find_metric('queue_requests', observations), nil)
+end
+
+g.test_set_filter_validation = function()
+    t.assert_error_msg_contains(
+        "Metric selector filter string must be 'all' or 'none'",
+        function()
+            metrics.set_filter('roles.crud-router', {})
+        end)
+
+    t.assert_error_msg_contains(
+        'Metric selector filter item must be a table with a non-empty ' ..
+        'selector field',
+        function()
+            metrics.set_filter({{name = 'roles.crud-router'}}, {})
+        end)
+
+    local Registry = require('metrics.registry')
+    local registry = Registry.new()
+
+    t.assert_error_msg_contains(
+        "Metric selector filter must be 'all', 'none', or an array of " ..
+        'selector objects',
+        function()
+            registry:set_filter(42, {})
+        end)
+end
+
+g.test_filter_custom_callbacks = function()
+    local crud = metrics.namespace('roles.crud-router')
+    local queue = metrics.namespace('roles.queue')
+    local crud_gauge = crud:gauge('crud_callback_runs')
+    local queue_gauge = queue:gauge('queue_callback_runs')
+    local crud_runs = 0
+    local queue_runs = 0
+
+    crud_gauge:set(0)
+    queue_gauge:set(0)
+    metrics.register_callback(function()
+        crud_runs = crud_runs + 1
+        crud_gauge:set(crud_runs)
+    end, {selector = 'roles.crud-router'})
+    metrics.register_callback(function()
+        queue_runs = queue_runs + 1
+        queue_gauge:set(queue_runs)
+    end, {selector = 'roles.queue'})
+
+    metrics.set_filter({{selector = 'roles.crud-router'}}, {})
+
+    local observations = metrics.collect({invoke_callbacks = true})
+    local crud_obs = utils.find_metric('crud_callback_runs', observations)
+    local queue_obs = utils.find_metric('queue_callback_runs', observations)
+
+    t.assert_equals(crud_obs[1].value, 1)
+    t.assert_equals(queue_obs, nil)
+    t.assert_equals(crud_runs, 1)
+    t.assert_equals(queue_runs, 0)
+end
+
+g.test_collectors_are_filtered = function()
+    local crud = metrics.namespace('roles.crud-router')
+    local queue = metrics.namespace('roles.queue')
+
+    crud:gauge('crud_requests'):set(1)
+    queue:gauge('queue_requests'):set(2)
+
+    metrics.set_filter('all', {{selector = 'roles.queue'}})
+
+    local collectors = metrics.collectors()
+    t.assert_not_equals(collectors.crud_requestsgauge, nil)
+    t.assert_equals(collectors.queue_requestsgauge, nil)
 end
 
 g.test_default_metrics_metainfo = function(cg)


### PR DESCRIPTION
This patch adds selector-based filtering for custom metrics.

Before this patch, the `metrics` module allowed applications to register custom collectors and callbacks, but there was no common way to group them and enable or disable them later through `metrics.cfg()`.

The patch introduces selectors for custom metrics. A selector may be attached to a collector or callback via metadata:

```lua
local metrics = require('metrics')

metrics.register_callback(function()
    in_flight:set(get_in_flight())
end, {selector = 'roles.crud-router'})
```

For convenience, metrics may also be registered through a namespace:

```lua
local metrics = require('metrics')

local crud = metrics.namespace('roles.crud-router')

crud:gauge('crud_requests'):set(1)
crud:gauge('crud_errors'):set(1)
```

The namespace prefixes registered collectors with hierarchical selectors:

```text
roles.crud-router.crud_requests
roles.crud-router.crud_errors
```

Selectors can be filtered with the new `metrics.set_filter()` API:

```lua
metrics.set_filter(
    {{selector = 'roles.crud-router'}},
    {{selector = 'roles.crud-router.crud_errors'}}
)
```

`include` enables matching selectors, `exclude` disables matching selectors, and `exclude` has priority. Matching is hierarchical, so `roles.crud-router` matches `roles.crud-router.crud_requests`.

`metrics.cfg()` now also accepts custom selector strings in `include` and `exclude`:

```lua
metrics.cfg{
    include = {'info', 'roles.crud-router'},
    exclude = {'roles.crud-router.crud_errors'},
}
```

Built-in Tarantool metric groups keep the existing behavior. Unknown strings in `include` / `exclude` are treated as custom selectors and are applied through the registry filter.

This lets applications and Tarantool roles expose custom metrics while still using the existing `metrics.include` / `metrics.exclude` configuration model.

Part of tarantool/tarantool#11358