### PR TITLE
test: fix memory_metrics test for OSX

### DIFF
--- a/test/tarantool/memory_metrics_test.lua
+++ b/test/tarantool/memory_metrics_test.lua
@@ -39,6 +39,8 @@ g.test_instance_metrics = function(cg)
 
         local memory_virt_metric = utils.find_metric('tnt_memory_virt', default_metrics)
         t.assert(memory_virt_metric)
-        t.assert_gt(memory_virt_metric[1].value, 0)
+        if jit.os == 'Linux' then
+            t.assert_gt(memory_virt_metric[1].value, 0)
+        end
     end)
 end


### PR DESCRIPTION
The test is failing with local run on macbook.
The original problem is that psutils is present for Linux only. 
