### PR TITLE
test: fix hotreload test isolation

### DIFF
--- a/test/metrics_test.lua
+++ b/test/metrics_test.lua
@@ -173,6 +173,12 @@ g.test_hotreload_old_registry_gets_filter = function(cg)
     cg.server:exec(function()
         local previous_registry = rawget(_G, '__metrics_registry')
         local previous_metrics_api = package.loaded['metrics.api']
+
+        local function restore()
+            rawset(_G, '__metrics_registry', previous_registry)
+            package.loaded['metrics.api'] = previous_metrics_api
+        end
+
         local old_registry = {
             collectors = {},
             callbacks = {},
@@ -184,6 +190,11 @@ g.test_hotreload_old_registry_gets_filter = function(cg)
 
         local metrics_api = require('metrics.api')
         local registry = rawget(_G, '__metrics_registry')
+
+        if metrics_api.registry ~= old_registry then
+            restore()
+            t.skip('built-in metrics loader keeps metrics.api cached')
+        end
 
         t.assert_equals(registry, old_registry)
         t.assert_not_equals(registry.filter, nil)
@@ -202,8 +213,7 @@ g.test_hotreload_old_registry_gets_filter = function(cg)
             exclude = {},
         })
 
-        rawset(_G, '__metrics_registry', previous_registry)
-        package.loaded['metrics.api'] = previous_metrics_api
+        restore()
     end)
 end
 


### PR DESCRIPTION
This patch fixes the test added for old registry migration on hot reload.

Follows up #543
