### PR TITLE
cfg: fix all selector exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `metrics.cfg{exclude = {'all'}}` so it excludes custom metric
+  selectors in addition to built-in metric groups (#548).
+
 ### Removed
 
 # [1.8.0] - 2026-06-10

--- a/metrics/cfg.lua
+++ b/metrics/cfg.lua
@@ -23,7 +23,10 @@ local function split_metric_groups_and_selectors(values, default_value,
     local default_metrics = {}
     local custom_selectors = {}
     for _, value in ipairs(values) do
-        if value == const.ALL or metrics_tarantool.is_default_metric(value) then
+        if value == const.ALL then
+            table.insert(default_metrics, value)
+            return default_metrics, const.ALL
+        elseif metrics_tarantool.is_default_metric(value) then
             table.insert(default_metrics, value)
         else
             table.insert(custom_selectors, {selector = value})

--- a/test/cfg_test.lua
+++ b/test/cfg_test.lua
@@ -253,6 +253,43 @@ group.test_custom_selectors_reconfiguration = function(g)
     end)
 end
 
+group.test_custom_selectors_exclude_all = function(g)
+    g.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
+        local crud = metrics.namespace('roles.crud-router')
+
+        metrics.cfg{
+            include = {'roles.crud-router'},
+            exclude = {'all'},
+        }
+
+        crud:gauge('crud_requests'):set(1)
+
+        local observations = metrics.collect{invoke_callbacks = true}
+        t.assert_equals(utils.find_metric('crud_requests', observations), nil)
+    end)
+end
+
+group.test_custom_selectors_include_all_exclude_all = function(g)
+    g.server:exec(function()
+        local metrics = require('metrics')
+        local utils = require('test.utils') -- luacheck: ignore 431
+        local crud = metrics.namespace('roles.crud-router')
+
+        metrics.cfg{
+            include = {'all'},
+            exclude = {'all'},
+        }
+
+        crud:gauge('crud_requests'):set(1)
+
+        local observations = metrics.collect{invoke_callbacks = true}
+        t.assert_equals(utils.find_metric('tnt_info_uptime', observations), nil)
+        t.assert_equals(utils.find_metric('crud_requests', observations), nil)
+    end)
+end
+
 group.test_cfg_clean_user_metrics = function(g)
     g.server:exec(function()
         local metrics = require('metrics')


### PR DESCRIPTION
This patch fixes a bug where `exclude = {'all'}` disabled only built-in metric groups, while custom metric selectors could still be collected.

Closes #547
