### PR TITLE
test: disable config checks in config_metrics_test

### DIFF
--- a/test/tarantool/config_metrics_test.lua
+++ b/test/tarantool/config_metrics_test.lua
@@ -59,6 +59,14 @@ local default_config =  {
     metrics = {
         include = {'all'},
     },
+    conditional = {
+        {
+            ['if'] = 'tarantool_version >= 3.8.1',
+            config = {
+                checks = 'off',
+            },
+        },
+    },
 }
 
 local function write_config(cg, config)


### PR DESCRIPTION
Set `config.checks` to `'off'` in `default_config` to avoid environment-dependent alerts (THP, readahead) in tests.

Part of tarantool/tarantool#12371
