### PR TITLE
Release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+### Removed
+
+# [1.8.1] - 2026-07-02
+
+This release fixes a bug where custom metrics selectors would continue
+to collect data with the `exclude = {'all'}` configuration.
+
+### Fixed
+
 - Fixed `metrics.cfg{exclude = {'all'}}` so it excludes custom metric
   selectors in addition to built-in metric groups (#548).
-
-### Removed
 
 # [1.8.0] - 2026-06-10
 

--- a/metrics/version.lua
+++ b/metrics/version.lua
@@ -1,4 +1,4 @@
 -- Сontains the module version.
 -- Requires manual update in case of release commit.
 
-return '1.8.0'
+return '1.8.1'


### PR DESCRIPTION
This release fixes a bug where custom metrics selectors would continue
to collect data with the `exclude = {'all'}` configuration.

### Fixed

- Fixed `metrics.cfg{exclude = {'all'}}` so it excludes custom metric selectors in addition to built-in metric groups (#548).
